### PR TITLE
Fix ES module import extension

### DIFF
--- a/src/utils/axios-client.ts
+++ b/src/utils/axios-client.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { isInIFrame } from "./common";
+import { isInIFrame } from "./common.js";
 import { v4 as uuidv4 } from "uuid";
 
 export class Base44Error extends Error {


### PR DESCRIPTION
## Summary
- Fix import of `./common` to `./common.js` in `axios-client.ts`

## Problem
The SDK was failing when consumed by other ES module projects because relative imports were missing the `.js` extension, which is required by ES module specification.

## Solution
Added `.js` extension to the relative import as required by ES modules.

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Verified ES module compliance