### PR TITLE
Add ES module compliance testing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit
+
+      - name: Test ES module compliance
+        run: npm run test:esm

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src",
-    "test": "vitest run",
+    "test": "npm run build && vitest run",
     "test:unit": "vitest run tests/unit",
     "test:e2e": "vitest run tests/e2e",
+    "test:esm": "npm run build && node test-esm-strict.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build"

--- a/test-esm-strict.mjs
+++ b/test-esm-strict.mjs
@@ -1,0 +1,16 @@
+/**
+ * Strict ES module test - runs with Node.js directly
+ * This will fail if imports don't have proper .js extensions
+ */
+import { createClient } from './dist/index.js';
+
+console.log('✅ ES module import successful');
+console.log('createClient:', typeof createClient);
+
+const client = createClient({
+  apiKey: 'test-key',
+  baseURL: 'https://api.test.com'
+});
+
+console.log('✅ Client creation successful');
+process.exit(0);

--- a/tests/esm-compliance.test.js
+++ b/tests/esm-compliance.test.js
@@ -1,0 +1,21 @@
+/**
+ * Test to verify ES module compliance by importing the built SDK
+ * This test runs against the compiled output to catch import issues
+ */
+import { createClient } from '../dist/index.js';
+import { describe, it, expect } from 'vitest';
+
+describe('ES Module Compliance', () => {
+  it('should import the SDK successfully from built dist', () => {
+    expect(createClient).toBeDefined();
+    expect(typeof createClient).toBe('function');
+  });
+
+  it('should create a client instance', () => {
+    const client = createClient({
+      apiKey: 'test-key',
+      baseURL: 'https://api.test.com'
+    });
+    expect(client).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add automated test to verify ES module compliance
- Integrate ES module test into CI pipeline
- Add npm script for running ES module tests

## Background
This adds testing infrastructure to catch ES module import issues that would break the SDK when consumed by other ES module projects.

## Changes
- `test-esm-strict.mjs`: Strict Node.js ES module test
- `tests/esm-compliance.test.js`: Vitest-based compliance test
- `package.json`: Added `test:esm` script and updated main test script
- `.github/workflows/unit-tests.yml`: Added ES module compliance check to CI

## Test plan
- [x] ES module test passes with correct imports
- [x] ES module test fails with incorrect imports (verified manually)
- [x] CI integration works