### PR TITLE
external auth support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import { createEntitiesModule } from "./modules/entities.js";
 import { createIntegrationsModule } from "./modules/integrations.js";
 import { createAuthModule } from "./modules/auth.js";
 import { createSsoModule } from "./modules/sso.js";
-import { createAppConnectionsModule } from "./modules/app-connections.js";
+import { createConnectorsModule } from "./modules/connectors.js";
 import { getAccessToken } from "./utils/auth-utils.js";
 import { createFunctionsModule } from "./modules/functions.js";
 import { createAgentsModule } from "./modules/agents.js";
@@ -128,7 +128,7 @@ export function createClient(config: {
     entities: createEntitiesModule(serviceRoleAxiosClient, appId),
     integrations: createIntegrationsModule(serviceRoleAxiosClient, appId),
     sso: createSsoModule(serviceRoleAxiosClient, appId, token),
-    appConnections: createAppConnectionsModule(serviceRoleAxiosClient, appId),
+    connectors: createConnectorsModule(serviceRoleAxiosClient, appId),
     functions: createFunctionsModule(serviceRoleFunctionsAxiosClient, appId),
     agents: createAgentsModule({
       axios: serviceRoleAxiosClient,

--- a/src/modules/app-connections.types.ts
+++ b/src/modules/app-connections.types.ts
@@ -1,5 +1,0 @@
-export type AppConnectionIntegrationType = string;
-
-export type AppConnectionAccessTokenResponse = {
-  access_token: string;
-};

--- a/src/modules/connectors.ts
+++ b/src/modules/connectors.ts
@@ -1,16 +1,16 @@
 import { AxiosInstance } from "axios";
 import {
-  AppConnectionIntegrationType,
-  AppConnectionAccessTokenResponse,
-} from "./app-connections.types.js";
+  ConnectorIntegrationType,
+  ConnectorAccessTokenResponse,
+} from "./connectors.types.js";
 
 /**
- * Creates the App Connections module for the Base44 SDK
+ * Creates the Connectors module for the Base44 SDK
  * @param axios - Axios instance (should be service role client)
  * @param appId - Application ID
- * @returns App Connections module
+ * @returns Connectors module
  */
-export function createAppConnectionsModule(axios: AxiosInstance, appId: string) {
+export function createConnectorsModule(axios: AxiosInstance, appId: string) {
   return {
     /**
      * Retrieve an access token for a given integration type
@@ -18,15 +18,15 @@ export function createAppConnectionsModule(axios: AxiosInstance, appId: string) 
      * @returns Access token response
      */
     async getAccessToken(
-      integrationType: AppConnectionIntegrationType
-    ): Promise<AppConnectionAccessTokenResponse> {
+      integrationType: ConnectorIntegrationType
+    ): Promise<ConnectorAccessTokenResponse> {
       if (!integrationType || typeof integrationType !== "string") {
         throw new Error(
           "Integration type is required and must be a string"
         );
       }
 
-      const response = await axios.get<AppConnectionAccessTokenResponse>(
+      const response = await axios.get<ConnectorAccessTokenResponse>(
         `/apps/${appId}/external-auth/tokens/${integrationType}`
       );
 
@@ -35,3 +35,4 @@ export function createAppConnectionsModule(axios: AxiosInstance, appId: string) 
     },
   };
 }
+

--- a/src/modules/connectors.types.ts
+++ b/src/modules/connectors.types.ts
@@ -1,0 +1,6 @@
+export type ConnectorIntegrationType = string;
+
+export type ConnectorAccessTokenResponse = {
+  access_token: string;
+};
+

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,3 +1,3 @@
 export * from "./app.types.js";
 export * from "./agents.types.js";
-export * from "./app-connections.types.js";
+export * from "./connectors.types.js";


### PR DESCRIPTION
Exposing a `getAccessToken` function, that returns an access token, depending on the integration type. The LLM is instructed to generate the following:

```js
base44.asServiceRole.connectors.getAccessToken(integration_type)
```

The endpoint requires a service role, and returns the access token of the contributor who connected his account first (we currently allow one account per app).