### PR TITLE
Docs draft workflow

### DIFF
--- a/.github/workflows/claude-docs-drafter.yml
+++ b/.github/workflows/claude-docs-drafter.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Run Claude Docs Drafter
         timeout-minutes: 10


### PR DESCRIPTION
Adding a workflow that checks new PRs to see if they have the appropriate docs. If not, it adds a comment to the PR with draft docs suggestions. The workflow uses the [docs writing skill](https://github.com/base44/javascript-sdk/blob/main/.claude/skills/sdk-docs-writing/SKILL.md) to understand how/where to write the docs.

If it adds docs, the workflow also adds a 'docs-draft' label to the PR so the tech writers can find it later and work on it.