### PR TITLE
Add SSO as a supported auth provider

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -60,13 +60,19 @@ export function createAuthModule(
       // Build the full redirect URL
       const redirectUrl = new URL(fromUrl, window.location.origin).toString();
 
-      // Build the provider login URL (google is the default, so no provider path needed)
-      const providerPath = provider === "google" ? "" : `/${provider}`;
-      const loginUrl = `${
-        options.appBaseUrl
-      }/api/apps/auth${providerPath}/login?app_id=${appId}&from_url=${encodeURIComponent(
-        redirectUrl
-      )}`;
+      const queryParams = `app_id=${appId}&from_url=${encodeURIComponent(redirectUrl)}`;
+
+      // SSO uses a different URL structure with appId in the path
+      let authPath: string;
+      if (provider === "sso") {
+        authPath = `/apps/${appId}/auth/sso/login`;
+      } else {
+        // Google is the default provider, so no provider path segment needed
+        const providerPath = provider === "google" ? "" : `/${provider}`;
+        authPath = `/apps/auth${providerPath}/login`;
+      }
+
+      const loginUrl = `${options.appBaseUrl}/api${authPath}?${queryParams}`;
 
       // Redirect to the provider login page
       window.location.href = loginUrl;

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -199,8 +199,9 @@ export interface AuthModule {
    * - `'microsoft'` - {@link https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow | Microsoft OAuth}. Enable Microsoft in your app's authentication settings before specifying this provider.
    * - `'facebook'` - {@link https://developers.facebook.com/docs/facebook-login | Facebook Login}. Enable Facebook in your app's authentication settings before using.
    * - `'apple'` - {@link https://developer.apple.com/sign-in-with-apple/ | Sign in with Apple}. Enable Apple in your app's authentication settings before using this provider.
+   * - `'sso'` - Enterprise SSO. Enable SSO in your app's authentication settings before using this provider.
    *
-   * @param provider - The authentication provider to use: `'google'`, `'microsoft'`, `'facebook'`, or `'apple'`.
+   * @param provider - The authentication provider to use: `'google'`, `'microsoft'`, `'facebook'`, `'apple'`, or `'sso'`.
    * @param fromUrl - URL to redirect to after successful authentication. Defaults to `'/'`.
    *
    * @example
@@ -219,6 +220,12 @@ export interface AuthModule {
    * ```typescript
    * // Apple
    * base44.auth.loginWithProvider('apple', '/dashboard');
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // SSO
+   * base44.auth.loginWithProvider('sso', '/dashboard');
    * ```
    */
   loginWithProvider(provider: string, fromUrl?: string): void;


### PR DESCRIPTION
## Summary
- Adds `'sso'` as a supported provider in `loginWithProvider`
- SSO uses a distinct URL structure: `/api/apps/{appId}/auth/sso/login`
- Refactored URL construction to extract shared query params and assemble the final URL from a common prefix/suffix
- Updated JSDoc in `auth.types.ts` to document SSO and add a usage example

## Test plan
- [ ] Call `loginWithProvider('sso', '/dashboard')` and verify redirect goes to `/api/apps/{appId}/auth/sso/login?app_id=...&from_url=...`
- [ ] Verify existing providers (google, microsoft, facebook, apple) still produce the correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)