### PR TITLE
UoU Connectors | Add getCurrentAppUserConnection function

### DIFF
--- a/src/modules/connectors.ts
+++ b/src/modules/connectors.ts
@@ -3,6 +3,7 @@ import {
   ConnectorIntegrationType,
   ConnectorAccessTokenResponse,
   ConnectorConnectionResponse,
+  AppUserConnectorConnectionResponse,
   ConnectorsModule,
   UserConnectorsModule,
 } from "./connectors.types.js";
@@ -78,7 +79,7 @@ export function createConnectorsModule(
 
     async getCurrentAppUserConnection(
       connectorId: string
-    ): Promise<ConnectorConnectionResponse> {
+    ): Promise<AppUserConnectorConnectionResponse> {
       if (!connectorId || typeof connectorId !== "string") {
         throw new Error("Connector ID is required and must be a string");
       }

--- a/src/modules/connectors.ts
+++ b/src/modules/connectors.ts
@@ -58,6 +58,9 @@ export function createConnectorsModule(
       };
     },
 
+    /**
+     * @deprecated Use getCurrentAppUserConnection(connectorId) and use the returned accessToken (and connectionConfig when needed) instead.
+     */
     async getCurrentAppUserAccessToken(
       connectorId: string
     ): Promise<string> {
@@ -71,6 +74,24 @@ export function createConnectorsModule(
 
       const data = response as unknown as { access_token: string };
       return data.access_token;
+    },
+
+    async getCurrentAppUserConnection(
+      connectorId: string
+    ): Promise<ConnectorConnectionResponse> {
+      if (!connectorId || typeof connectorId !== "string") {
+        throw new Error("Connector ID is required and must be a string");
+      }
+
+      const response = await axios.get(
+        `/apps/${appId}/app-user-auth/connectors/${connectorId}/token`
+      );
+
+      const data = response as unknown as ConnectorAccessTokenResponse;
+      return {
+        accessToken: data.access_token,
+        connectionConfig: data.connection_config ?? null,
+      };
     },
   };
 }

--- a/src/modules/connectors.types.ts
+++ b/src/modules/connectors.types.ts
@@ -236,6 +236,8 @@ export interface ConnectorsModule {
   /**
    * Retrieves an OAuth access token for an end user's connection to a specific connector.
    *
+   * @deprecated Use {@link getCurrentAppUserConnection} instead.
+   *
    * Returns the OAuth token string that belongs to the currently authenticated end user
    * for the specified connector.
    *
@@ -253,6 +255,28 @@ export interface ConnectorsModule {
    * ```
    */
   getCurrentAppUserAccessToken(connectorId: string): Promise<string>;
+
+  /**
+   * Retrieves the OAuth access token and connection configuration for an end user's
+   * connection to a specific connector.
+   *
+   * Returns both the OAuth token and any connection-specific configuration that
+   * belongs to the currently authenticated end user for the specified connector.
+   *
+   * @param connectorId - The connector ID (OrgConnector database ID).
+   * @returns Promise resolving to a {@link ConnectorConnectionResponse} with `accessToken` and `connectionConfig`.
+   *
+   * @example
+   * ```typescript
+   * // Get the end user's connection details for a connector
+   * const { accessToken, connectionConfig } = await base44.asServiceRole.connectors.getCurrentAppUserConnection('abc123def');
+   *
+   * const response = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events', {
+   *   headers: { 'Authorization': `Bearer ${accessToken}` }
+   * });
+   * ```
+   */
+  getCurrentAppUserConnection(connectorId: string): Promise<ConnectorConnectionResponse>;
 }
 
 /**

--- a/src/modules/connectors.types.ts
+++ b/src/modules/connectors.types.ts
@@ -39,6 +39,16 @@ export interface ConnectorConnectionResponse {
 }
 
 /**
+ * Connection details for an app-user connector.
+ */
+export interface AppUserConnectorConnectionResponse {
+  /** The OAuth access token for the end user's connection. */
+  accessToken: string;
+  /** Key-value configuration for the connection, or `null` if the connector does not provide one. */
+  connectionConfig: Record<string, string> | null;
+}
+
+/**
  * Connectors module for managing app-scoped OAuth tokens for external services.
  *
  * This module allows you to retrieve OAuth access tokens for external services that the app has connected to. Connectors are app-scoped. When an app builder connects an integration like Google Calendar, Slack, or GitHub, all users of the app share that same connection.
@@ -264,7 +274,7 @@ export interface ConnectorsModule {
    * belongs to the currently authenticated end user for the specified connector.
    *
    * @param connectorId - The connector ID (OrgConnector database ID).
-   * @returns Promise resolving to a {@link ConnectorConnectionResponse} with `accessToken` and `connectionConfig`.
+   * @returns Promise resolving to an {@link AppUserConnectorConnectionResponse} with `accessToken` and `connectionConfig`.
    *
    * @example
    * ```typescript
@@ -276,7 +286,7 @@ export interface ConnectorsModule {
    * });
    * ```
    */
-  getCurrentAppUserConnection(connectorId: string): Promise<ConnectorConnectionResponse>;
+  getCurrentAppUserConnection(connectorId: string): Promise<AppUserConnectorConnectionResponse>;
 }
 
 /**

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import nock from "nock";
 import { createClient } from "../../src/index.ts";
+import type { AppUserConnectorConnectionResponse } from "../../src/modules/connectors.types.ts";
 
 describe("Connectors module – getConnection", () => {
   const appId = "test-app-id";
@@ -130,7 +131,7 @@ describe("Connectors module – getCurrentAppUserConnection", () => {
       .get(`/api/apps/${appId}/app-user-auth/connectors/connector-1/token`)
       .reply(200, apiResponse);
 
-    const connection =
+    const connection: AppUserConnectorConnectionResponse =
       await base44.asServiceRole.connectors.getCurrentAppUserConnection(
         "connector-1"
       );
@@ -153,7 +154,7 @@ describe("Connectors module – getCurrentAppUserConnection", () => {
       .get(`/api/apps/${appId}/app-user-auth/connectors/connector-2/token`)
       .reply(200, apiResponse);
 
-    const connection =
+    const connection: AppUserConnectorConnectionResponse =
       await base44.asServiceRole.connectors.getCurrentAppUserConnection(
         "connector-2"
       );
@@ -174,7 +175,7 @@ describe("Connectors module – getCurrentAppUserConnection", () => {
       .get(`/api/apps/${appId}/app-user-auth/connectors/connector-3/token`)
       .reply(200, apiResponse);
 
-    const connection =
+    const connection: AppUserConnectorConnectionResponse =
       await base44.asServiceRole.connectors.getCurrentAppUserConnection(
         "connector-3"
       );

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -98,3 +98,103 @@ describe("Connectors module – getConnection", () => {
     ).rejects.toThrow("Integration type is required and must be a string");
   });
 });
+
+describe("Connectors module – getCurrentAppUserConnection", () => {
+  const appId = "test-app-id";
+  const serverUrl = "https://base44.app";
+  const serviceToken = "service-token-123";
+  let base44: ReturnType<typeof createClient>;
+  let scope: nock.Scope;
+
+  beforeEach(() => {
+    base44 = createClient({
+      serverUrl,
+      appId,
+      serviceToken,
+    });
+    scope = nock(serverUrl);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("extracts accessToken and connectionConfig from API response", async () => {
+    const apiResponse = {
+      access_token: "user-oauth-token-abc123",
+      integration_type: "jira",
+      connection_config: { subdomain: "my-company" },
+    };
+
+    scope
+      .get(`/api/apps/${appId}/app-user-auth/connectors/connector-1/token`)
+      .reply(200, apiResponse);
+
+    const connection =
+      await base44.asServiceRole.connectors.getCurrentAppUserConnection(
+        "connector-1"
+      );
+
+    expect(connection).toBeDefined();
+    expect(connection.accessToken).toBe("user-oauth-token-abc123");
+    expect(connection.connectionConfig).toEqual({
+      subdomain: "my-company",
+    });
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test("returns connectionConfig as null when API omits connection_config", async () => {
+    const apiResponse = {
+      access_token: "user-token-only",
+      integration_type: "slack",
+    };
+
+    scope
+      .get(`/api/apps/${appId}/app-user-auth/connectors/connector-2/token`)
+      .reply(200, apiResponse);
+
+    const connection =
+      await base44.asServiceRole.connectors.getCurrentAppUserConnection(
+        "connector-2"
+      );
+
+    expect(connection.accessToken).toBe("user-token-only");
+    expect(connection.connectionConfig).toBeNull();
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test("returns connectionConfig as null when API sends null connection_config", async () => {
+    const apiResponse = {
+      access_token: "user-token-only",
+      integration_type: "github",
+      connection_config: null,
+    };
+
+    scope
+      .get(`/api/apps/${appId}/app-user-auth/connectors/connector-3/token`)
+      .reply(200, apiResponse);
+
+    const connection =
+      await base44.asServiceRole.connectors.getCurrentAppUserConnection(
+        "connector-3"
+      );
+
+    expect(connection.accessToken).toBe("user-token-only");
+    expect(connection.connectionConfig).toBeNull();
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test("throws when connectorId is empty string", async () => {
+    await expect(
+      base44.asServiceRole.connectors.getCurrentAppUserConnection("")
+    ).rejects.toThrow("Connector ID is required and must be a string");
+  });
+
+  test("throws when connectorId is not a string", async () => {
+    await expect(
+      base44.asServiceRole.connectors.getCurrentAppUserConnection(
+        null as unknown as string
+      )
+    ).rejects.toThrow("Connector ID is required and must be a string");
+  });
+});


### PR DESCRIPTION
Similar to connectors - there's a need for a function for getConnection
in order to return an object with access token and connection config

That will allow UOU connectors for snowflake and databricks