### PR TITLE
docs: update InvokeLLM model options to match backend

### DIFF
--- a/.claude/skills/sdk-docs-writing/references/pipeline-config.md
+++ b/.claude/skills/sdk-docs-writing/references/pipeline-config.md
@@ -8,6 +8,20 @@ cd docs
 mint dev
 ```
 
+## Running in a git worktree
+
+Git worktrees don't have their own `node_modules`. Before running `npm run create-docs` from a worktree, symlink in the main repo's `node_modules`:
+
+```bash
+# If a partial node_modules exists (e.g. from a failed npm install), remove it first
+rm -rf /path/to/worktree/javascript-sdk/node_modules
+
+ln -s /Users/samm/Projects/base44-workspace/javascript-sdk/node_modules \
+  /path/to/worktree/javascript-sdk/node_modules
+```
+
+Then `npm run create-docs` works normally from the worktree.
+
 ## Pipeline configuration files
 
 | File | Purpose |

--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -48,9 +48,9 @@ export interface InvokeLLMParams {
   prompt: string;
   /** Optionally specify a model to override the app-level model setting for this specific call.
    *
-   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5"`, `"gemini_3_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`
+   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5"`, `"gpt_5_4"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`
    */
-  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gemini_3_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6';
+  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gpt_5_4' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6';
   /** If set to `true`, the LLM will use Google Search, Maps, and News to gather real-time context before answering.
    * @default false
    */


### PR DESCRIPTION
## Summary

- Adds `gpt_5_4` to the `InvokeLLMParams.model` type and JSDoc options list
- Renames `gemini_3_pro` → `gemini_3_1_pro` to match the backend `RuntimeModel` enum
- Documents the `node_modules` symlink approach for running `create-docs` from a git worktree

## Test plan

- [ ] Verify `npm run create-docs` regenerates correctly
- [ ] Check generated `integrations.mdx` reflects the updated model list

🤖 Generated with [Claude Code](https://claude.com/claude-code)