### PR TITLE
Add waiting_for_user_input to AgentMessageToolCall status type

### DIFF
--- a/src/modules/agents.types.ts
+++ b/src/modules/agents.types.ts
@@ -48,7 +48,7 @@ export interface AgentMessageToolCall {
   /** Arguments passed to the tool as JSON string. */
   arguments_string: string;
   /** Status of the tool call. */
-  status: "running" | "success" | "error" | "stopped";
+  status: "running" | "success" | "error" | "stopped" | "waiting_for_user_input";
   /** Results from the tool call. */
   results?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `"waiting_for_user_input"` to the `status` union in `AgentMessageToolCall` in `agents.types.ts`

## What drifted

The backend `ToolCall` model in `apper/backend/app/ai/models/message.py` has:

```python
status: Literal["running", "success", "error", "stopped", "waiting_for_user_input"]
```

But the SDK type was missing `"waiting_for_user_input"`:

```typescript
// Before
status: "running" | "success" | "error" | "stopped";

// After
status: "running" | "success" | "error" | "stopped" | "waiting_for_user_input";
```

## Test plan

- [ ] Verify `AgentMessageToolCall.status` includes `"waiting_for_user_input"` in the TypeScript type
- [ ] Run `npm run create-docs-local` to regenerate SDK docs (companion PR: base44-dev/mintlify-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)