### PR TITLE
Add gpt_5_5 and claude_opus_4_7 to InvokeLLMParams model union

### DIFF
--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -48,9 +48,9 @@ export interface InvokeLLMParams {
   prompt: string;
   /** Optionally specify a model to override the app-level model setting for this specific call.
    *
-   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5"`, `"gpt_5_4"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`
+   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5"`, `"gpt_5_4"`, `"gpt_5_5"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`, `"claude_opus_4_7"`
    */
-  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gpt_5_4' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6';
+  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gpt_5_4' | 'gpt_5_5' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6' | 'claude_opus_4_7';
   /** If set to `true`, the LLM will use Google Search, Maps, and News to gather real-time context before answering.
    * @default false
    */


### PR DESCRIPTION
## Summary

- Adds `gpt_5_5` and `claude_opus_4_7` to the `model` union on `InvokeLLMParams` in `integrations.types.ts`

## What drifted

apper's `RuntimeModel` enum has these two models but the SDK type was missing them:

```typescript
// Before
model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gpt_5_4' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6';

// After
model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gpt_5_4' | 'gpt_5_5' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6' | 'claude_opus_4_7';
```

Companion docs PR: base44-dev/mintlify-docs (llm-models-fix branch)

## Test plan
- [ ] Verify `InvokeLLMParams.model` includes `gpt_5_5` and `claude_opus_4_7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)