### PR TITLE
fix(client): apply access token before analytics module init

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -151,6 +151,17 @@ export function createClient(config: CreateClientConfig): Base44Client {
     }
   );
 
+  // Apply the access token before any module that may issue authenticated
+  // requests during construction (notably analytics, which fires an init
+  // event whose flush calls auth.me()). Without this, the first User/me
+  // request is built before setToken runs and goes out unauthenticated.
+  if (typeof window !== "undefined") {
+    const accessToken = token || getAccessToken();
+    if (accessToken) {
+      userAuthModule.setToken(accessToken);
+    }
+  }
+
   const userModules = {
     entities: createEntitiesModule({
       axios: axiosClient,
@@ -229,15 +240,6 @@ export function createClient(config: CreateClientConfig): Base44Client {
       }
     },
   };
-
-  // Always try to get token from localStorage or URL parameters
-  if (typeof window !== "undefined") {
-    // Get token from URL or localStorage
-    const accessToken = token || getAccessToken();
-    if (accessToken) {
-      userModules.auth.setToken(accessToken);
-    }
-  }
 
   // If authentication is required, verify token and redirect to login if needed
   if (requiresAuth && typeof window !== "undefined") {


### PR DESCRIPTION
## Summary

Some (all?) sdk apps will log a 401 to /entities/User/me early when the page load.
<img width="857" height="250" alt="Screenshot 2026-05-12 at 14 49 22" src="https://github.com/user-attachments/assets/7fe3045d-96fb-4ed0-9841-7456d8029115" />

`createAnalyticsModule()` fires an initialization event during construction. The first flush calls `auth.me()`, which synchronously builds the axios request using `defaults.headers.common` *at call time*. Because `setToken(accessToken)` ran later in `createClient()`, that first `User/me` request went out with no `Authorization` header — returning 401/403 on apps that require auth (e.g. `workspace_with_login`).

This moves the localStorage/URL token application to immediately after `createAuthModule(...)`, so all downstream module construction (analytics included) sees an authenticated axios client.


## Repro

1. Put a valid `base44_access_token` in `localStorage`.
2. `createClient({ appId })` against an app that requires auth.
3. Watch network: the SDK's `GET /api/apps/{appId}/entities/User/me` fires without `Authorization` and 4xxs. Every subsequent request includes the header.

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit` (144/144)
- [ ] Manual: localStorage-token repro before/after on an auth-protected app
- [x] Manual: tested this pr version on the package on a custom site - 403 disappeared 

🤖 Generated with [Claude Code](https://claude.com/claude-code)