### PR TITLE
Fix updateMe docs: clarify only custom fields are updatable

### DIFF
--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -141,7 +141,7 @@ export interface AuthModule {
    * You can update `role` and any custom fields defined in your
    * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).
    * The `role` value must match one of the options defined in your User entity schema.
-   * The following fields are read-only and cannot be changed with this method:
+   * The following fields are read-only and can't be changed with this method:
    * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.
    *
    * @param data - Object containing the fields to update.

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -140,7 +140,7 @@ export interface AuthModule {
    *
    * You can update `role` and any [custom fields](/developers/backend/resources/entities/user-schema#custom-fields) defined in your
    * User entity schema.
-   * The `role` value must match one of the defined options.
+   * The `role` value must be either `'user'` or `'admin'`.
    * <Note>
    * The following fields are read-only and can't be changed with this method:
    * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -140,6 +140,7 @@ export interface AuthModule {
    *
    * You can update `role` and any custom fields defined in your
    * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).
+   * The `role` value must match one of the options defined in your User entity schema.
    * The following fields are read-only and cannot be changed with this method:
    * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.
    *

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -136,22 +136,15 @@ export interface AuthModule {
   me(): Promise<User>;
 
   /**
-   * Updates the current authenticated user's information.
+   * Updates the current authenticated user's custom profile fields.
    *
-   * Only the fields included in the data object will be updated.
-   * Commonly updated fields include `full_name` and custom profile fields.
+   * Only custom fields defined in your User entity schema can be updated.
+   * Platform-managed fields (`id`, `email`, `full_name`, `created_date`,
+   * `updated_date`, `app_id`, `is_verified`, `is_service`, `disabled`, and `role`)
+   * are read-only and cannot be changed with this method.
    *
-   * @param data - Object containing the fields to update.
+   * @param data - Object containing the custom fields to update.
    * @returns Promise resolving to the updated user data.
-   *
-   * @example
-   * ```typescript
-   * // Update specific fields
-   * const updatedUser = await base44.auth.updateMe({
-   *   full_name: 'John Doe'
-   * });
-   * console.log(`Updated user: ${updatedUser.full_name}`);
-   * ```
    *
    * @example
    * ```typescript
@@ -164,7 +157,7 @@ export interface AuthModule {
    * ```
    */
   updateMe(
-    data: Partial<Omit<User, "id" | "created_date" | "updated_date">>
+    data: Record<string, any>
   ): Promise<User>;
 
   /**

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -139,7 +139,7 @@ export interface AuthModule {
    * Updates the current authenticated user's information.
    *
    * You can update `role` and any custom fields defined in your
-   * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).
+   * User entity schema.
    * The `role` value must match one of the defined options.
    * <Note>
    * The following fields are read-only and can't be changed with this method:

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -139,9 +139,9 @@ export interface AuthModule {
    * Updates the current authenticated user's custom profile fields.
    *
    * Only custom fields defined in your User entity schema can be updated.
-   * Platform-managed fields (`id`, `email`, `full_name`, `created_date`,
-   * `updated_date`, `app_id`, `is_verified`, `is_service`, `disabled`, and `role`)
-   * are read-only and cannot be changed with this method.
+   * The following platform-managed fields are read-only and cannot be changed
+   * with this method: `id`, `email`, `full_name`, `created_date`, `updated_date`,
+   * `app_id`, `is_verified`, `is_service`, `disabled`, and `role`.
    *
    * @param data - Object containing the custom fields to update.
    * @returns Promise resolving to the updated user data.

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -138,7 +138,7 @@ export interface AuthModule {
   /**
    * Updates the current authenticated user's information.
    *
-   * You can update `role` and any custom fields defined in your
+   * You can update `role` and any [custom fields](/developers/backend/resources/entities/user-schema#custom-fields) defined in your
    * User entity schema.
    * The `role` value must match one of the defined options.
    * <Note>

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -136,7 +136,7 @@ export interface AuthModule {
   me(): Promise<User>;
 
   /**
-   * Updates fields on the current authenticated user's profile.
+   * Updates the current authenticated user's information.
    *
    * You can update `role` and any custom fields defined in your
    * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -136,22 +136,22 @@ export interface AuthModule {
   me(): Promise<User>;
 
   /**
-   * Updates the current authenticated user's custom profile fields.
+   * Updates fields on the current authenticated user's profile.
    *
-   * Only custom fields defined in your [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema) can be updated.
-   * The following platform-managed fields are read-only and cannot be changed
-   * with this method: `id`, `email`, `full_name`, `created_date`, `updated_date`,
-   * `app_id`, `is_verified`, `is_service`, `disabled`, and `role`.
+   * You can update `role` and any custom fields defined in your
+   * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).
+   * The following fields are read-only and cannot be changed with this method:
+   * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.
    *
-   * @param data - Object containing the custom fields to update.
+   * @param data - Object containing the fields to update.
    * @returns Promise resolving to the updated user data.
    *
    * @example
    * ```typescript
-   * // Update custom fields defined in your User entity
+   * // Update role and custom fields defined in your User entity
    * await base44.auth.updateMe({
+   *   role: 'admin',
    *   bio: 'Software developer',
-   *   phone: '+1234567890',
    *   preferences: { theme: 'dark' }
    * });
    * ```

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -141,8 +141,10 @@ export interface AuthModule {
    * You can update `role` and any custom fields defined in your
    * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).
    * The `role` value must match one of the options defined in your User entity schema.
+   * <Note>
    * The following fields are read-only and can't be changed with this method:
    * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.
+   * </Note>
    *
    * @param data - Object containing the fields to update.
    * @returns Promise resolving to the updated user data.

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -138,7 +138,7 @@ export interface AuthModule {
   /**
    * Updates the current authenticated user's custom profile fields.
    *
-   * Only custom fields defined in your User entity schema can be updated.
+   * Only custom fields defined in your [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema) can be updated.
    * The following platform-managed fields are read-only and cannot be changed
    * with this method: `id`, `email`, `full_name`, `created_date`, `updated_date`,
    * `app_id`, `is_verified`, `is_service`, `disabled`, and `role`.

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -140,7 +140,7 @@ export interface AuthModule {
    *
    * You can update `role` and any custom fields defined in your
    * [User entity schema](https://docs.base44.com/developers/backend/resources/entities/user-schema).
-   * The `role` value must match one of the options defined in your User entity schema.
+   * The `role` value must match one of the defined options.
    * <Note>
    * The following fields are read-only and can't be changed with this method:
    * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.


### PR DESCRIPTION
## Summary
- Removes the incorrect claim that `full_name` can be updated via `updateMe()`
- Lists all read-only platform-managed fields: `id`, `email`, `full_name`, `created_date`, `updated_date`, `app_id`, `is_verified`, `is_service`, `disabled`, `role`
- Updates the parameter type from `Partial<Omit<User, ...>>` to `Record<string, any>` to match the actual implementation
- Replaces the misleading `full_name` example with a custom fields example
- Regenerated docs copied to `mintlify-docs` via `npm run create-docs-local`

## Test plan
- [ ] Verify the updated `updateMe()` docs render correctly in the SDK reference