### PR TITLE
fix(realtime): debounce empty room leave churn

### DIFF
--- a/src/utils/socket-utils.ts
+++ b/src/utils/socket-utils.ts
@@ -118,6 +118,8 @@ export function RoomsSocket({ config }: { config: RoomsSocketConfig }) {
   }
 
   function disconnect() {
+    clearPendingRoomLeaves();
+
     if (socket) {
       socket.disconnect();
     }
@@ -157,6 +159,17 @@ export function RoomsSocket({ config }: { config: RoomsSocketConfig }) {
 
     clearTimeout(pendingLeave);
     delete pendingRoomLeaves[room];
+  }
+
+  function clearPendingRoomLeaves() {
+    Object.keys(pendingRoomLeaves).forEach((room) => {
+      clearTimeout(pendingRoomLeaves[room]);
+      delete pendingRoomLeaves[room];
+
+      if ((roomsToListeners[room]?.length ?? 0) === 0) {
+        delete roomsToListeners[room];
+      }
+    });
   }
 
   function scheduleRoomLeave(room: TSocketRoom) {

--- a/src/utils/socket-utils.ts
+++ b/src/utils/socket-utils.ts
@@ -31,6 +31,8 @@ type TEvent = keyof RoomsSocketEventsMap["listen"];
 
 type THandler<E extends TEvent> = RoomsSocketEventsMap["listen"][E];
 
+const ROOM_LEAVE_GRACE_MS = 250;
+
 function initializeSocket(
   config: RoomsSocketConfig,
   handlers: Partial<RoomsSocketEventsMap["listen"]>
@@ -73,14 +75,20 @@ export function RoomsSocket({ config }: { config: RoomsSocketConfig }) {
     TSocketRoom,
     Partial<RoomsSocketEventsMap["listen"]>[]
   > = {};
+  const pendingRoomLeaves: Record<TSocketRoom, ReturnType<typeof setTimeout>> =
+    {};
 
   const handlers: RoomsSocketEventsMap["listen"] = {
     connect: async () => {
       const promises: Promise<void>[] = [];
       Object.keys(roomsToListeners).forEach((room) => {
-        joinRoom(room);
         const listeners = getListeners(room);
-        listeners?.forEach(({ connect }) => {
+        if (listeners.length === 0) {
+          return;
+        }
+
+        joinRoom(room);
+        listeners.forEach(({ connect }) => {
           const promise = async () => connect?.();
           promises.push(promise());
         });
@@ -141,11 +149,37 @@ export function RoomsSocket({ config }: { config: RoomsSocketConfig }) {
     return roomsToListeners[room] ?? [];
   }
 
+  function cancelPendingRoomLeave(room: TSocketRoom) {
+    const pendingLeave = pendingRoomLeaves[room];
+    if (!pendingLeave) {
+      return;
+    }
+
+    clearTimeout(pendingLeave);
+    delete pendingRoomLeaves[room];
+  }
+
+  function scheduleRoomLeave(room: TSocketRoom) {
+    cancelPendingRoomLeave(room);
+    pendingRoomLeaves[room] = setTimeout(() => {
+      delete pendingRoomLeaves[room];
+
+      if ((roomsToListeners[room]?.length ?? 0) > 0) {
+        return;
+      }
+
+      leaveRoom(room);
+      delete roomsToListeners[room];
+    }, ROOM_LEAVE_GRACE_MS);
+  }
+
   const subscribeToRoom = (
     room: TSocketRoom,
     handlers: Partial<{ [k in TEvent]: THandler<k> }>
   ) => {
-    if (!roomsToListeners[room]) {
+    if (roomsToListeners[room]) {
+      cancelPendingRoomLeave(room);
+    } else {
       joinRoom(room);
       roomsToListeners[room] = [];
     }
@@ -163,8 +197,7 @@ export function RoomsSocket({ config }: { config: RoomsSocketConfig }) {
         roomsToListeners[room]?.filter((listener) => listener !== handlers) ??
         [];
       if (roomsToListeners[room].length === 0) {
-        leaveRoom(room);
-        delete roomsToListeners[room];
+        scheduleRoomLeave(room);
       }
     };
   };

--- a/tests/unit/socket-utils.test.ts
+++ b/tests/unit/socket-utils.test.ts
@@ -117,4 +117,20 @@ describe("RoomsSocket", () => {
     expect(socketMock.emit).toHaveBeenCalledTimes(2);
     expect(socketMock.emit).toHaveBeenLastCalledWith("leave", "room-a");
   });
+
+  test("clears pending room leaves when the socket is replaced", () => {
+    vi.useFakeTimers();
+    const socket = createRoomsSocket();
+    const unsubscribe = socket.subscribeToRoom("room-a", {});
+
+    unsubscribe();
+    socket.updateConfig({ token: "next-token" });
+    socket.subscribeToRoom("room-a", {});
+
+    vi.advanceTimersByTime(250);
+
+    expect(socketMock.emit).toHaveBeenCalledTimes(2);
+    expect(socketMock.emit).toHaveBeenNthCalledWith(1, "join", "room-a");
+    expect(socketMock.emit).toHaveBeenNthCalledWith(2, "join", "room-a");
+  });
 });

--- a/tests/unit/socket-utils.test.ts
+++ b/tests/unit/socket-utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { RoomsSocket } from "../../src/utils/socket-utils.ts";
 
 const socketMock = vi.hoisted(() => ({
@@ -27,6 +27,10 @@ describe("RoomsSocket", () => {
     socketMock.listeners = {};
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function createRoomsSocket() {
     return RoomsSocket({
       config: {
@@ -40,6 +44,7 @@ describe("RoomsSocket", () => {
   }
 
   test("shares one room join across multiple listeners until the last unsubscribe", () => {
+    vi.useFakeTimers();
     const socket = createRoomsSocket();
     const firstUnsubscribe = socket.subscribeToRoom("room-a", {});
     const secondUnsubscribe = socket.subscribeToRoom("room-a", {});
@@ -53,15 +58,21 @@ describe("RoomsSocket", () => {
 
     secondUnsubscribe();
 
+    expect(socketMock.emit).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(250);
+
     expect(socketMock.emit).toHaveBeenCalledTimes(2);
     expect(socketMock.emit).toHaveBeenLastCalledWith("leave", "room-a");
   });
 
-  test("rejoins a room after its last listener unsubscribes", () => {
+  test("rejoins a room after its last listener unsubscribe grace elapses", () => {
+    vi.useFakeTimers();
     const socket = createRoomsSocket();
     const firstUnsubscribe = socket.subscribeToRoom("room-a", {});
 
     firstUnsubscribe();
+    vi.advanceTimersByTime(250);
     socket.subscribeToRoom("room-a", {});
 
     expect(socketMock.emit).toHaveBeenNthCalledWith(1, "join", "room-a");
@@ -70,14 +81,40 @@ describe("RoomsSocket", () => {
   });
 
   test("unsubscribe is idempotent after the room is left", () => {
+    vi.useFakeTimers();
     const socket = createRoomsSocket();
     const unsubscribe = socket.subscribeToRoom("room-a", {});
 
     unsubscribe();
     unsubscribe();
 
+    vi.advanceTimersByTime(250);
+
     expect(socketMock.emit).toHaveBeenCalledTimes(2);
     expect(socketMock.emit).toHaveBeenNthCalledWith(1, "join", "room-a");
     expect(socketMock.emit).toHaveBeenNthCalledWith(2, "leave", "room-a");
+  });
+
+  test("does not leave and rejoin during brief unsubscribe-resubscribe churn", () => {
+    vi.useFakeTimers();
+    const socket = createRoomsSocket();
+    const firstUnsubscribe = socket.subscribeToRoom("room-a", {});
+
+    firstUnsubscribe();
+
+    expect(socketMock.emit).toHaveBeenCalledTimes(1);
+
+    const secondUnsubscribe = socket.subscribeToRoom("room-a", {});
+
+    vi.advanceTimersByTime(250);
+
+    expect(socketMock.emit).toHaveBeenCalledTimes(1);
+    expect(socketMock.emit).toHaveBeenCalledWith("join", "room-a");
+
+    secondUnsubscribe();
+    vi.advanceTimersByTime(250);
+
+    expect(socketMock.emit).toHaveBeenCalledTimes(2);
+    expect(socketMock.emit).toHaveBeenLastCalledWith("leave", "room-a");
   });
 });


### PR DESCRIPTION
## What changed
- Keep a realtime room joined for a short 250ms grace period after its last local listener unsubscribes.
- Cancel the pending leave if another listener subscribes to the same room during that grace window.
- Keep existing behavior after the grace period: empty rooms still emit `leave`, are removed locally, and can later rejoin normally.

## Why
React render/effect churn can briefly unsubscribe and resubscribe to the same logical room. Before this change, that produced immediate `leave` -> `join` traffic even when the app was effectively still interested in the room. Under repeated churn, that creates unnecessary socket and Redis room-tracking pressure.

## How it works
`RoomsSocket` now tracks pending room-leave timers by room. The last unsubscribe schedules `leave` instead of emitting it synchronously. A new subscription for the same room clears the timer and reuses the existing room membership. The connect handler skips rooms that have no active listeners, so a room in its grace window is not rejoined after reconnect unless it becomes active again.

## Risk
Low. Empty rooms may remain joined for up to 250ms longer than before. During that window, incoming updates are ignored because there are no local listeners. The timer is per room and is cleared on resubscribe.

## Validation
- `npm run test:unit -- tests/unit/socket-utils.test.ts tests/unit/entities-subscribe.test.ts`
- `npm run lint`
- `npm run build`