### PR TITLE
Sync SDK types with backend drift (June 2026)

### DIFF
--- a/src/modules/connectors.types.ts
+++ b/src/modules/connectors.types.ts
@@ -87,11 +87,13 @@ export interface AppUserConnectorConnectionResponse {
  * | Calendly | `calendly` |
  * | ClickUp | `clickup` |
  * | Contentful | `contentful` |
+ * | Databricks | `databricks` |
  * | Discord | `discord` |
  * | Dropbox | `dropbox` |
  * | GitHub | `github` |
  * | GitLab | `gitlab` |
  * | Gmail | `gmail` |
+ * | Google Ads | `googleads` |
  * | Google Analytics | `google_analytics` |
  * | Google BigQuery | `googlebigquery` |
  * | Google Calendar | `googlecalendar` |
@@ -112,10 +114,12 @@ export interface AppUserConnectorConnectionResponse {
  * | Microsoft OneDrive | `one_drive` |
  * | Notion | `notion` |
  * | Outlook | `outlook` |
+ * | QuickBooks | `quickbooks` |
  * | Salesforce | `salesforce` |
  * | SharePoint | `share_point` |
  * | Slack User | `slack` |
  * | Slack Bot | `slackbot` |
+ * | Snowflake | `snowflake` |
  * | Splitwise | `splitwise` |
  * | Supabase | `supabase` |
  * | TikTok | `tiktok` |

--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -48,9 +48,9 @@ export interface InvokeLLMParams {
   prompt: string;
   /** Optionally specify a model to override the app-level model setting for this specific call.
    *
-   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5"`, `"gpt_5_4"`, `"gpt_5_5"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`, `"claude_opus_4_7"`
+   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5_4"`, `"gpt_5_5"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`, `"claude_opus_4_7"`, `"claude_opus_4_8"`
    */
-  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5' | 'gpt_5_4' | 'gpt_5_5' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6' | 'claude_opus_4_7';
+  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5_4' | 'gpt_5_5' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6' | 'claude_opus_4_7' | 'claude_opus_4_8';
   /** If set to `true`, the LLM will use Google Search, Maps, and News to gather real-time context before answering.
    * @default false
    */


### PR DESCRIPTION
## Summary
- Add `claude_opus_4_8` to the `InvokeLLM` model union and remove deprecated `gpt_5`, matching `RuntimeModel` in apper.
- Add missing connector type identifiers (`googleads`, `databricks`, `quickbooks`, `snowflake`) to the SDK connectors table, matching `IntegrationType` in apper.

## Test plan
- [ ] Verify `integrations.types.ts` model union matches `RuntimeModel` (excluding `automatic`).
- [ ] Verify `connectors.types.ts` connector table matches `IntegrationType` in apper.
- [ ] Pair with mintlify-docs PR for regenerated SDK reference pages.


Made with [Cursor](https://cursor.com)