### PR TITLE
[codex] fix Deno deleteMany transport

### DIFF
--- a/src/utils/axios-client.ts
+++ b/src/utils/axios-client.ts
@@ -174,6 +174,18 @@ export function createAxiosClient({
 
   // Add origin URL in browser environment
   client.interceptors.request.use((config) => {
+    // Axios selects its Node HTTP adapter in Deno, where DELETE requests with
+    // a body fail in the node:http compatibility layer. deleteMany relies on
+    // that request shape, while Deno's native fetch handles it correctly.
+    if (
+      typeof (globalThis as typeof globalThis & { Deno?: unknown }).Deno !==
+        "undefined" &&
+      config.method?.toLowerCase() === "delete" &&
+      config.data !== undefined
+    ) {
+      config.adapter = "fetch";
+    }
+
     if (typeof window !== "undefined") {
       config.headers.set("X-Origin-URL", window.location.href);
     }

--- a/tests/unit/axios-client.test.ts
+++ b/tests/unit/axios-client.test.ts
@@ -1,0 +1,70 @@
+import axios from "axios";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createAxiosClient } from "../../src/utils/axios-client.ts";
+
+vi.mock("axios", () => ({
+  default: {
+    create: vi.fn(),
+  },
+}));
+
+function createMockClient() {
+  return {
+    defaults: { headers: { common: {} } },
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  };
+}
+
+describe("createAxiosClient Deno adapter selection", () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    vi.mocked(axios.create).mockReturnValue(mockClient as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  function getRequestInterceptor() {
+    createAxiosClient({ baseURL: "https://example.com/api" });
+    return mockClient.interceptors.request.use.mock.calls[0][0];
+  }
+
+  test("uses the fetch adapter for DELETE requests with a body in Deno", () => {
+    vi.stubGlobal("Deno", {});
+    const intercept = getRequestInterceptor();
+    const config = { method: "delete", data: { status: "done" }, headers: new Headers() };
+
+    expect(intercept(config).adapter).toBe("fetch");
+  });
+
+  test("keeps the default adapter for bodyless DELETE requests in Deno", () => {
+    vi.stubGlobal("Deno", {});
+    const intercept = getRequestInterceptor();
+    const config = { method: "delete", headers: new Headers() };
+
+    expect(intercept(config).adapter).toBeUndefined();
+  });
+
+  test("keeps the default adapter for other request methods in Deno", () => {
+    vi.stubGlobal("Deno", {});
+    const intercept = getRequestInterceptor();
+    const config = { method: "post", data: { title: "new" }, headers: new Headers() };
+
+    expect(intercept(config).adapter).toBeUndefined();
+  });
+
+  test("keeps the default adapter outside Deno", () => {
+    const intercept = getRequestInterceptor();
+    const config = { method: "delete", data: { status: "done" }, headers: new Headers() };
+
+    expect(intercept(config).adapter).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

- route Deno `DELETE` requests with a body through Axios's fetch adapter
- preserve existing adapter selection for browsers, Node, Cloudflare, bodyless deletes, and non-DELETE requests
- add focused unit coverage for the runtime/method/body selection matrix

## Why

`entities.<Entity>.deleteMany(query)` sends a JSON body with `DELETE`. In legacy Base44 Deno v1 functions, Axios selects its Node HTTP adapter, which enters Deno's `node:http` compatibility layer and fails after approximately 15 seconds with `Base44Error: connection error`.

This is tracked internally as `BUG-494` and was reproduced across SDK 0.8.25 and 0.8.31.

## Production reproduction

An isolated Deno v1 Base44 app produced this comparison against the same production entity endpoint and query:

| Transport | Result | Time |
|---|---:|---:|
| native Deno fetch | HTTP 200, deleted 3 | 416 ms |
| Axios default HTTP adapter | connection error | 15,132 ms |
| Axios forced fetch adapter | HTTP 200, deleted 3 | 274 ms |
| Axios HTTP adapter, `maxRedirects: 0` | connection error | 15,106 ms |
| Axios HTTP adapter, explicit `Content-Length` | connection error | 15,164 ms |
| SDK `deleteMany` | connection error | 15,138 ms |

The failure stack enters `axios/lib/adapters/http.js` and Deno `node:http`. Successful native/fetch-adapter calls produce the platform's `entity_entries_deleted_bulk` log; failed HTTP-adapter calls never reach the backend API.

The same SDK call succeeds on Base44's Cloudflare Functions runtime, where Axios uses fetch because the Node HTTP adapter is unavailable.

## Impact

`deleteMany` works again in legacy Deno backend functions without changing the public SDK method or backend API contract.

## Validation

- `npm run test:unit -- tests/unit/axios-client.test.ts` — 157 tests passed
- `npm run build`
- `npm run lint`
- `git diff --check`
