### PR TITLE
fix(axios): gate anonymous-id header on request-time Authorization

### DIFF
--- a/src/utils/axios-client.ts
+++ b/src/utils/axios-client.ts
@@ -177,10 +177,10 @@ export function createAxiosClient({
   client.interceptors.request.use((config) => {
     if (typeof window !== "undefined") {
       config.headers.set("X-Origin-URL", window.location.href);
-      // On unauthenticated clients, attach a stable anonymous visitor id so the
-      // backend can support anonymous agent access (conversation grouping +
-      // ownership). Authenticated clients are identified by their token instead.
-      if (!token) {
+      // On unauthenticated requests, attach a stable anonymous visitor id so the
+      // backend can support anonymous agent access (conversation grouping + ownership).
+      // Authenticated requests are identified by their Authorization header instead.
+      if (!config.headers.get("Authorization")) {
         config.headers.set("X-Base44-Anonymous-Id", getAnalyticsSessionId());
       }
     }

--- a/tests/unit/anonymous-visitor-header.test.ts
+++ b/tests/unit/anonymous-visitor-header.test.ts
@@ -31,8 +31,18 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-async function captureRequestHeaders(token?: string) {
+async function captureRequestHeaders(
+  token?: string,
+  { tokenSetAfterConstruction }: { tokenSetAfterConstruction?: string } = {}
+) {
   const client = createAxiosClient({ baseURL: "https://api", token });
+  // Mirrors the common browser path: auth.setToken() applies the Authorization
+  // header on the client's defaults after the client has already been built.
+  if (tokenSetAfterConstruction) {
+    client.defaults.headers.common[
+      "Authorization"
+    ] = `Bearer ${tokenSetAfterConstruction}`;
+  }
   let captured: any;
   client.defaults.adapter = async (config) => {
     captured = config;
@@ -62,5 +72,13 @@ describe("anonymous visitor header", () => {
     const headers = await captureRequestHeaders("a-real-token");
     expect(headers.get("X-Base44-Anonymous-Id")).toBeFalsy();
     expect(headers.get("Authorization")).toBe("Bearer a-real-token");
+  });
+
+  test("token set after construction (browser setToken path) omits the anonymous header", async () => {
+    const headers = await captureRequestHeaders(undefined, {
+      tokenSetAfterConstruction: "a-real-token",
+    });
+    expect(headers.get("Authorization")).toBe("Bearer a-real-token");
+    expect(headers.get("X-Base44-Anonymous-Id")).toBeFalsy();
   });
 });


### PR DESCRIPTION
To fix issue from #198 

> src/utils/axios-client.ts:181 — the !token guard checks construction-time state, not live auth, so authenticated browser users send the anon header anyway.
The interceptor closes over token from createAxiosClient(...). The dominant browser auth path does not pass token to the constructor — client.ts:158-163 calls userAuthModule.setToken(getAccessToken()), which sets axios.defaults.headers.common["Authorization"] after the client is built. The closure token stays undefined, so every request from a logged-in user now carries both Authorization: Bearer … and X-Base44-Anonymous-Id. This is the exact opposite of the stated invariant ("authenticated clients … no anon header"). The unit test only exercises the constructor-token path, so it passes while the common path is broken. A request-time check (e.g. !config.headers.get("Authorization")) would reflect actual auth state. Note the socket path (config.token ?? getAccessToken()) already resolves the live token correctly — the two paths are inconsistent.