### PR TITLE
feat(ai-gateway): add base44.aiGateway.connection()

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -191,7 +191,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       token,
     }),
-    aiGateway: createAiGatewayModule({ serverUrl, token }),
+    aiGateway: createAiGatewayModule({ serverUrl, appBaseUrl: normalizedAppBaseUrl, token }),
     appLogs: createAppLogsModule(axiosClient, appId),
     users: createUsersModule(axiosClient, appId),
     analytics: createAnalyticsModule({
@@ -235,7 +235,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       token,
     }),
-    aiGateway: createAiGatewayModule({ serverUrl, token: serviceToken }),
+    aiGateway: createAiGatewayModule({ serverUrl, appBaseUrl: normalizedAppBaseUrl, token: serviceToken }),
     appLogs: createAppLogsModule(serviceRoleAxiosClient, appId),
     cleanup: () => {
       if (socket) {
@@ -395,6 +395,7 @@ export function createClientFromRequest(request: Request): Base44Client {
   );
   const appId = request.headers.get("Base44-App-Id");
   const serverUrlHeader = request.headers.get("Base44-Api-Url");
+  const appBaseUrlHeader = request.headers.get("Base44-App-Base-Url");
   const functionsVersion = request.headers.get("Base44-Functions-Version");
   const stateHeader = request.headers.get("Base44-State");
 
@@ -442,6 +443,7 @@ export function createClientFromRequest(request: Request): Base44Client {
 
   return createClient({
     serverUrl: serverUrlHeader || "https://base44.app",
+    appBaseUrl: appBaseUrlHeader ?? undefined,
     appId,
     token: userToken,
     serviceToken: serviceRoleToken,

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ import {
 import { getAccessToken } from "./utils/auth-utils.js";
 import { createFunctionsModule } from "./modules/functions.js";
 import { createAgentsModule } from "./modules/agents.js";
+import { createAiGatewayModule } from "./modules/ai-gateway.js";
 import { createAppLogsModule } from "./modules/app-logs.js";
 import { createUsersModule } from "./modules/users.js";
 import { RoomsSocket, RoomsSocketConfig } from "./utils/socket-utils.js";
@@ -190,6 +191,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       token,
     }),
+    aiGateway: createAiGatewayModule({ serverUrl, token }),
     appLogs: createAppLogsModule(axiosClient, appId),
     users: createUsersModule(axiosClient, appId),
     analytics: createAnalyticsModule({
@@ -233,6 +235,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       token,
     }),
+    aiGateway: createAiGatewayModule({ serverUrl, token: serviceToken }),
     appLogs: createAppLogsModule(serviceRoleAxiosClient, appId),
     cleanup: () => {
       if (socket) {

--- a/src/client.types.ts
+++ b/src/client.types.ts
@@ -8,6 +8,7 @@ import type {
 } from "./modules/connectors.types.js";
 import type { FunctionsModule } from "./modules/functions.types.js";
 import type { AgentsModule } from "./modules/agents.types.js";
+import type { AiGatewayModule } from "./modules/ai-gateway.types.js";
 import type { AppLogsModule } from "./modules/app-logs.types.js";
 import type { AnalyticsModule } from "./modules/analytics.types.js";
 
@@ -87,6 +88,8 @@ export interface CreateClientConfig {
 export interface Base44Client {
   /** {@link AgentsModule | Agents module} for managing AI agent conversations. */
   agents: AgentsModule;
+  /** {@link AiGatewayModule | AI Gateway module} for connecting to the Base44 AI Gateway with your own SDK. */
+  aiGateway: AiGatewayModule;
   /** {@link AnalyticsModule | Analytics module} for tracking custom events in your app. */
   analytics: AnalyticsModule;
   /** {@link AppLogsModule | App logs module} for tracking app usage. */
@@ -129,6 +132,8 @@ export interface Base44Client {
   readonly asServiceRole: {
     /** {@link AgentsModule | Agents module} with elevated permissions. */
     agents: AgentsModule;
+    /** {@link AiGatewayModule | AI Gateway module} with the service-role token. */
+    aiGateway: AiGatewayModule;
     /** {@link AppLogsModule | App logs module} with elevated permissions. */
     appLogs: AppLogsModule;
     /** {@link ConnectorsModule | Connectors module} for OAuth token retrieval. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,11 @@ export type {
   CreateConversationParams,
 } from "./modules/agents.types.js";
 
+export type {
+  AiGatewayModule,
+  GatewayConnection,
+} from "./modules/ai-gateway.types.js";
+
 export type { AppLogsModule } from "./modules/app-logs.types.js";
 
 export type { SsoModule, SsoAccessTokenResponse } from "./modules/sso.types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export type {
 
 export type {
   AiGatewayModule,
-  GatewayConnection,
+  AiGatewayConnection,
 } from "./modules/ai-gateway.types.js";
 
 export type { AppLogsModule } from "./modules/app-logs.types.js";

--- a/src/modules/ai-gateway.ts
+++ b/src/modules/ai-gateway.ts
@@ -7,10 +7,16 @@ import {
 
 export function createAiGatewayModule({
   serverUrl,
+  appBaseUrl,
   token,
 }: AiGatewayModuleConfig): AiGatewayModule {
+  // The gateway is a domain-resolved route: it only answers on the app's own
+  // domain. In the browser serverUrl is that domain already; in backend
+  // functions serverUrl is the API host, so prefer the app's public base URL
+  // (propagated via the Base44-App-Base-Url header) when available.
+  const gatewayOrigin = appBaseUrl || serverUrl;
   const connection = (): AiGatewayConnection => ({
-    baseURL: `${serverUrl}/api/ai/openai/v1`,
+    baseURL: `${gatewayOrigin}/api/ai/openai/v1`,
     token: token ?? getAccessToken() ?? "",
   });
 

--- a/src/modules/ai-gateway.ts
+++ b/src/modules/ai-gateway.ts
@@ -1,0 +1,20 @@
+import { getAccessToken } from "../utils/auth-utils.js";
+import {
+  AiGatewayModule,
+  AiGatewayModuleConfig,
+  GatewayConnection,
+} from "./ai-gateway.types.js";
+
+export function createAiGatewayModule({
+  serverUrl,
+  token,
+}: AiGatewayModuleConfig): AiGatewayModule {
+  const connection = (): GatewayConnection => ({
+    baseURL: `${serverUrl}/api/ai/unified/v1`,
+    token: token ?? getAccessToken() ?? "",
+  });
+
+  return {
+    connection,
+  };
+}

--- a/src/modules/ai-gateway.ts
+++ b/src/modules/ai-gateway.ts
@@ -10,7 +10,7 @@ export function createAiGatewayModule({
   token,
 }: AiGatewayModuleConfig): AiGatewayModule {
   const connection = (): AiGatewayConnection => ({
-    baseURL: `${serverUrl}/api/ai/unified/v1`,
+    baseURL: `${serverUrl}/api/ai/openai/v1`,
     token: token ?? getAccessToken() ?? "",
   });
 

--- a/src/modules/ai-gateway.ts
+++ b/src/modules/ai-gateway.ts
@@ -10,10 +10,6 @@ export function createAiGatewayModule({
   appBaseUrl,
   token,
 }: AiGatewayModuleConfig): AiGatewayModule {
-  // The gateway is a domain-resolved route: it only answers on the app's own
-  // domain. In the browser serverUrl is that domain already; in backend
-  // functions serverUrl is the API host, so prefer the app's public base URL
-  // (propagated via the Base44-App-Base-Url header) when available.
   const gatewayOrigin = appBaseUrl || serverUrl;
   const connection = (): AiGatewayConnection => ({
     baseURL: `${gatewayOrigin}/api/ai/openai/v1`,

--- a/src/modules/ai-gateway.ts
+++ b/src/modules/ai-gateway.ts
@@ -2,14 +2,14 @@ import { getAccessToken } from "../utils/auth-utils.js";
 import {
   AiGatewayModule,
   AiGatewayModuleConfig,
-  GatewayConnection,
+  AiGatewayConnection,
 } from "./ai-gateway.types.js";
 
 export function createAiGatewayModule({
   serverUrl,
   token,
 }: AiGatewayModuleConfig): AiGatewayModule {
-  const connection = (): GatewayConnection => ({
+  const connection = (): AiGatewayConnection => ({
     baseURL: `${serverUrl}/api/ai/unified/v1`,
     token: token ?? getAccessToken() ?? "",
   });

--- a/src/modules/ai-gateway.types.ts
+++ b/src/modules/ai-gateway.types.ts
@@ -2,7 +2,8 @@
  * A connection to the Base44 AI Gateway.
  *
  * Contains the base URL and bearer token to use with any OpenAI-compatible client
- * (the OpenAI SDK, Mastra, and others) pointed at the Base44 AI Gateway.
+ * (OpenAI SDK, Mastra, Vercel AI SDK, and others) pointed at the Base44 AI
+ * Gateway.
  */
 export interface AiGatewayConnection {
   /** Base URL of the gateway's OpenAI-compatible endpoint. */
@@ -18,38 +19,72 @@ export interface AiGatewayConnection {
 export interface AiGatewayModuleConfig {
   /** Server URL */
   serverUrl?: string;
-  /** The app's own public base URL (e.g. https://my-app.base44.app). Preferred over
-   * serverUrl for the gateway URL, since the gateway resolves the app by domain. */
+  /** The app's own public base URL (e.g. https://my-app.base44.app). */
   appBaseUrl?: string;
   /** Authentication token */
   token?: string;
 }
 
 /**
- * The AI Gateway module.
+ * AI Gateway module for calling Base44's managed AI models from your own code.
  *
- * Exposes the connection details for the Base44 AI Gateway so you can call it from
- * your own code using any OpenAI-compatible SDK — for example, to build a custom
- * agent on top of the gateway.
+ * The gateway exposes an OpenAI-compatible Chat Completions endpoint, so any
+ * OpenAI-compatible SDK works against it:
+ * - Build custom AI agents with agent SDKs such as Mastra or the Vercel AI SDK
+ * - Uses your app's models, billing, and credit quota, no API key to manage
+ *
+ * Available in user authentication mode (`base44.aiGateway`) and with the
+ * service-role token via `base44.asServiceRole.aiGateway`.
  */
 export interface AiGatewayModule {
   /**
    * Gets the connection details for the Base44 AI Gateway.
    *
-   * Returns the `baseURL` and `token` to pass to any OpenAI-compatible client (the
-   * OpenAI SDK, Mastra, and others), so you can call the gateway from your own code
-   * without constructing the URL or handling the token yourself.
+   * Returns the `baseURL` and `token` to pass to any OpenAI-compatible client.
    *
    * The `token` is the current caller's bearer token: the app user's token for
    * `base44.aiGateway`, or the service-role token for `base44.asServiceRole.aiGateway`.
-   * When the caller is unauthenticated, `token` is an empty string and gateway
-   * requests will be rejected.
+   * When the caller is unauthenticated, `token` is an empty string.
    *
    * @returns The gateway {@linkcode AiGatewayConnection | connection} (`baseURL` and `token`).
    *
    * @example
    * ```typescript
-   * // Inside a backend function, call the gateway with any OpenAI-compatible SDK
+   * // Build an AI agent with Mastra on top of the gateway, inside a backend function
+   * import { createClientFromRequest } from 'npm:@base44/sdk';
+   * import { Agent } from 'npm:@mastra/core/agent';
+   * import { createTool } from 'npm:@mastra/core/tools';
+   * import { createOpenAICompatible } from 'npm:@ai-sdk/openai-compatible';
+   * import { z } from 'npm:zod';
+   *
+   * Deno.serve(async (req) => {
+   *   const base44 = createClientFromRequest(req);
+   *   const { baseURL, token } = base44.aiGateway.connection();
+   *   const models = createOpenAICompatible({ name: 'base44', baseURL, apiKey: token });
+   *
+   *   const agent = new Agent({
+   *     id: 'order-helper',
+   *     name: 'order-helper',
+   *     instructions: 'Help the user with their orders.',
+   *     model: models('claude_sonnet_4_6'),
+   *     tools: {
+   *       lookupOrder: createTool({
+   *         id: 'lookup-order',
+   *         description: 'Fetch an order by id',
+   *         inputSchema: z.object({ orderId: z.string() }),
+   *         execute: async ({ orderId }) => base44.entities.Order.get(orderId),
+   *       }),
+   *     },
+   *   });
+   *
+   *   const { text } = await agent.generate('Where is order 123?');
+   *   return Response.json({ text });
+   * });
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Call a model directly with the OpenAI SDK
    * import { createClientFromRequest } from 'npm:@base44/sdk';
    * import OpenAI from 'npm:openai';
    *

--- a/src/modules/ai-gateway.types.ts
+++ b/src/modules/ai-gateway.types.ts
@@ -4,7 +4,7 @@
  * Contains the base URL and bearer token to use with any OpenAI-compatible client
  * (the OpenAI SDK, Mastra, and others) pointed at the Base44 AI Gateway.
  */
-export interface GatewayConnection {
+export interface AiGatewayConnection {
   /** Base URL of the gateway's OpenAI-compatible endpoint. */
   baseURL: string;
   /** Bearer token used to authenticate requests to the gateway. */
@@ -39,8 +39,10 @@ export interface AiGatewayModule {
    *
    * The `token` is the current caller's bearer token: the app user's token for
    * `base44.aiGateway`, or the service-role token for `base44.asServiceRole.aiGateway`.
+   * When the caller is unauthenticated, `token` is an empty string and gateway
+   * requests will be rejected.
    *
-   * @returns The gateway {@linkcode GatewayConnection | connection} (`baseURL` and `token`).
+   * @returns The gateway {@linkcode AiGatewayConnection | connection} (`baseURL` and `token`).
    *
    * @example
    * ```typescript
@@ -61,5 +63,5 @@ export interface AiGatewayModule {
    * });
    * ```
    */
-  connection(): GatewayConnection;
+  connection(): AiGatewayConnection;
 }

--- a/src/modules/ai-gateway.types.ts
+++ b/src/modules/ai-gateway.types.ts
@@ -18,6 +18,9 @@ export interface AiGatewayConnection {
 export interface AiGatewayModuleConfig {
   /** Server URL */
   serverUrl?: string;
+  /** The app's own public base URL (e.g. https://my-app.base44.app). Preferred over
+   * serverUrl for the gateway URL, since the gateway resolves the app by domain. */
+  appBaseUrl?: string;
   /** Authentication token */
   token?: string;
 }

--- a/src/modules/ai-gateway.types.ts
+++ b/src/modules/ai-gateway.types.ts
@@ -1,0 +1,65 @@
+/**
+ * A connection to the Base44 AI Gateway.
+ *
+ * Contains the base URL and bearer token to use with any OpenAI-compatible client
+ * (the OpenAI SDK, Mastra, and others) pointed at the Base44 AI Gateway.
+ */
+export interface GatewayConnection {
+  /** Base URL of the gateway's OpenAI-compatible endpoint. */
+  baseURL: string;
+  /** Bearer token used to authenticate requests to the gateway. */
+  token: string;
+}
+
+/**
+ * Configuration for the AI Gateway module.
+ * @internal
+ */
+export interface AiGatewayModuleConfig {
+  /** Server URL */
+  serverUrl?: string;
+  /** Authentication token */
+  token?: string;
+}
+
+/**
+ * The AI Gateway module.
+ *
+ * Exposes the connection details for the Base44 AI Gateway so you can call it from
+ * your own code using any OpenAI-compatible SDK — for example, to build a custom
+ * agent on top of the gateway.
+ */
+export interface AiGatewayModule {
+  /**
+   * Gets the connection details for the Base44 AI Gateway.
+   *
+   * Returns the `baseURL` and `token` to pass to any OpenAI-compatible client (the
+   * OpenAI SDK, Mastra, and others), so you can call the gateway from your own code
+   * without constructing the URL or handling the token yourself.
+   *
+   * The `token` is the current caller's bearer token: the app user's token for
+   * `base44.aiGateway`, or the service-role token for `base44.asServiceRole.aiGateway`.
+   *
+   * @returns The gateway {@linkcode GatewayConnection | connection} (`baseURL` and `token`).
+   *
+   * @example
+   * ```typescript
+   * // Inside a backend function, call the gateway with any OpenAI-compatible SDK
+   * import { createClientFromRequest } from 'npm:@base44/sdk';
+   * import OpenAI from 'npm:openai';
+   *
+   * Deno.serve(async (req) => {
+   *   const base44 = createClientFromRequest(req);
+   *   const { baseURL, token } = base44.aiGateway.connection();
+   *
+   *   const openai = new OpenAI({ baseURL, apiKey: token });
+   *   const res = await openai.chat.completions.create({
+   *     model: 'claude_sonnet_4_6',
+   *     messages: [{ role: 'user', content: 'Hello!' }],
+   *   });
+   *   return Response.json({ text: res.choices[0].message.content });
+   * });
+   * ```
+   */
+  connection(): GatewayConnection;
+}

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,4 +1,5 @@
 export * from "./app.types.js";
 export * from "./agents.types.js";
+export * from "./ai-gateway.types.js";
 export * from "./connectors.types.js";
 export * from "./analytics.types.js";

--- a/tests/unit/ai-gateway.test.ts
+++ b/tests/unit/ai-gateway.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "vitest";
+import { createClient } from "../../src/index.ts";
+
+describe("AI Gateway Module", () => {
+  const appId = "test-app-id";
+  const serverUrl = "https://api.base44.com";
+  const baseURL = `${serverUrl}/api/ai/unified/v1`;
+
+  describe("connection", () => {
+    test("should return the unified gateway baseURL", () => {
+      const base44 = createClient({ serverUrl, appId });
+      expect(base44.aiGateway.connection().baseURL).toBe(baseURL);
+    });
+
+    test("should return an empty token when unauthenticated", () => {
+      const base44 = createClient({ serverUrl, appId });
+      expect(base44.aiGateway.connection().token).toBe("");
+    });
+
+    test("should use the user token when authenticated", () => {
+      const base44 = createClient({ serverUrl, appId, token: "user-token" });
+      expect(base44.aiGateway.connection()).toEqual({
+        baseURL,
+        token: "user-token",
+      });
+    });
+
+    test("should use the service-role token via asServiceRole", () => {
+      const base44 = createClient({
+        serverUrl,
+        appId,
+        token: "user-token",
+        serviceToken: "service-token",
+      });
+      expect(base44.asServiceRole.aiGateway.connection()).toEqual({
+        baseURL,
+        token: "service-token",
+      });
+    });
+  });
+});

--- a/tests/unit/ai-gateway.test.ts
+++ b/tests/unit/ai-gateway.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { createClient } from "../../src/index.ts";
+import { createClient, createClientFromRequest } from "../../src/index.ts";
 
 describe("AI Gateway Module", () => {
   const appId = "test-app-id";
@@ -23,6 +23,45 @@ describe("AI Gateway Module", () => {
         baseURL,
         token: "user-token",
       });
+    });
+
+    test("should prefer appBaseUrl over serverUrl (domain-resolved gateway)", () => {
+      const base44 = createClient({
+        serverUrl,
+        appBaseUrl: "https://my-app.base44.app",
+        appId,
+      });
+      expect(base44.aiGateway.connection().baseURL).toBe(
+        "https://my-app.base44.app/api/ai/openai/v1"
+      );
+    });
+
+    test("should build from the Base44-App-Base-Url header in backend functions", () => {
+      const request = new Request("https://functions.internal/run", {
+        headers: {
+          "Base44-App-Id": appId,
+          "Base44-Api-Url": serverUrl,
+          "Base44-App-Base-Url": "https://my-app.base44.app",
+          Authorization: "Bearer user-token",
+        },
+      });
+      const base44 = createClientFromRequest(request);
+      expect(base44.aiGateway.connection()).toEqual({
+        baseURL: "https://my-app.base44.app/api/ai/openai/v1",
+        token: "user-token",
+      });
+    });
+
+    test("should fall back to serverUrl when the app-base-url header is absent", () => {
+      const request = new Request("https://functions.internal/run", {
+        headers: {
+          "Base44-App-Id": appId,
+          "Base44-Api-Url": serverUrl,
+          Authorization: "Bearer user-token",
+        },
+      });
+      const base44 = createClientFromRequest(request);
+      expect(base44.aiGateway.connection().baseURL).toBe(baseURL);
     });
 
     test("should use the service-role token via asServiceRole", () => {

--- a/tests/unit/ai-gateway.test.ts
+++ b/tests/unit/ai-gateway.test.ts
@@ -4,10 +4,10 @@ import { createClient } from "../../src/index.ts";
 describe("AI Gateway Module", () => {
   const appId = "test-app-id";
   const serverUrl = "https://api.base44.com";
-  const baseURL = `${serverUrl}/api/ai/unified/v1`;
+  const baseURL = `${serverUrl}/api/ai/openai/v1`;
 
   describe("connection", () => {
-    test("should return the unified gateway baseURL", () => {
+    test("should return the OpenAI-compatible gateway baseURL", () => {
       const base44 = createClient({ serverUrl, appId });
       expect(base44.aiGateway.connection().baseURL).toBe(baseURL);
     });


### PR DESCRIPTION
Adds `base44.aiGateway.connection()`, which returns `{ baseURL, token }` for the Base44 AI Gateway. This lets apps call the gateway from their own code with any OpenAI-compatible SDK (OpenAI, Mastra, etc.) without hardcoding the URL or handling the token.

Available on the user client, and with the service-role token via `base44.asServiceRole.aiGateway`.

```js
const { baseURL, token } = base44.aiGateway.connection();
const openai = new OpenAI({ baseURL, apiKey: token });
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)