### PR TITLE
Add Dependabot (cooldown + grouped) with patch/minor auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,35 @@
+# Dependabot: security + version updates with a 7-day cooldown, grouped to cut churn.
+# Patch/minor are auto-merged by .github/workflows/dependabot-auto-merge.yml; majors are
+# left for a human (and the holistic security bot surfaces majors/no-fix advisories with
+# remediation guidance). Security updates (advisory-driven) also honor the cooldown/groups.
 version: 2
 updates:
-  # Keep package.json dependencies patched. Combined with GitHub's
-  # Dependabot security updates (enabled in repo Settings > Security),
-  # this opens PRs for both routine version bumps and CVE fixes.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
     groups:
-      # Batch low-risk dev tooling updates into a single PR to cut noise.
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
 
-  # Keep the GitHub Actions used by these workflows up to date.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(actions)"
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot's patch/minor updates once required checks pass; leave majors for
+# a human. Rule-based (semver) — the deeper, investigating merge judgment lives in the
+# separate holistic security bot.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-merge patch/minor
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Leave majors for a human
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "$PR_URL" --body "🚧 Major update — not auto-merged (policy: auto-merge patch/minor only). Leaving for human review."


### PR DESCRIPTION
## What

Sets up Dependabot for this repo as part of the dependency-security **hybrid**: Dependabot handles the mechanical patch/minor security + version updates (with a cooldown, grouped, auto-merged when safe); the separate holistic bot handles majors / no-fix advisories with remediation guidance.

- `.github/dependabot.yml` — `npm` + `github-actions`, **daily**, **7-day cooldown**, grouped minor/patch, `dependencies` label. Security updates (advisory-driven) honor the same cooldown/groups.
- `.github/workflows/dependabot-auto-merge.yml` — patch/minor → `gh pr merge --auto --squash` (merges once this repo's CI passes); **major → comment, left for a human**.

## ⚠️ Repo settings needed (admin) — not doable via this PR
Please enable on the repo:
- **Dependabot alerts** + **Dependabot security updates** (Settings → Code security)
- **Allow auto-merge** (Settings → General → Pull Requests)

Without "Allow auto-merge", the auto-merge step will no-op/fail; without alerts+security-updates you won't get advisory-driven PRs.

## Notes
- This repo has CI, so auto-merge waits for green checks.
- Majors aren't auto-merged by design — they're the holistic bot's / a human's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)