### PR TITLE
fix(ai-gateway): drop the Base44-App-Base-Url header path

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -191,7 +191,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       token,
     }),
-    aiGateway: createAiGatewayModule({ serverUrl, appBaseUrl: normalizedAppBaseUrl, token }),
+    aiGateway: createAiGatewayModule({ serverUrl, token }),
     appLogs: createAppLogsModule(axiosClient, appId),
     users: createUsersModule(axiosClient, appId),
     analytics: createAnalyticsModule({
@@ -235,7 +235,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       token,
     }),
-    aiGateway: createAiGatewayModule({ serverUrl, appBaseUrl: normalizedAppBaseUrl, token: serviceToken }),
+    aiGateway: createAiGatewayModule({ serverUrl, token: serviceToken }),
     appLogs: createAppLogsModule(serviceRoleAxiosClient, appId),
     cleanup: () => {
       if (socket) {
@@ -395,7 +395,6 @@ export function createClientFromRequest(request: Request): Base44Client {
   );
   const appId = request.headers.get("Base44-App-Id");
   const serverUrlHeader = request.headers.get("Base44-Api-Url");
-  const appBaseUrlHeader = request.headers.get("Base44-App-Base-Url");
   const functionsVersion = request.headers.get("Base44-Functions-Version");
   const stateHeader = request.headers.get("Base44-State");
 
@@ -443,7 +442,6 @@ export function createClientFromRequest(request: Request): Base44Client {
 
   return createClient({
     serverUrl: serverUrlHeader || "https://base44.app",
-    appBaseUrl: appBaseUrlHeader ?? undefined,
     appId,
     token: userToken,
     serviceToken: serviceRoleToken,

--- a/src/modules/ai-gateway.ts
+++ b/src/modules/ai-gateway.ts
@@ -7,12 +7,10 @@ import {
 
 export function createAiGatewayModule({
   serverUrl,
-  appBaseUrl,
   token,
 }: AiGatewayModuleConfig): AiGatewayModule {
-  const gatewayOrigin = appBaseUrl || serverUrl;
   const connection = (): AiGatewayConnection => ({
-    baseURL: `${gatewayOrigin}/api/ai/openai/v1`,
+    baseURL: `${serverUrl}/api/ai/openai/v1`,
     token: token ?? getAccessToken() ?? "",
   });
 

--- a/src/modules/ai-gateway.types.ts
+++ b/src/modules/ai-gateway.types.ts
@@ -19,8 +19,6 @@ export interface AiGatewayConnection {
 export interface AiGatewayModuleConfig {
   /** Server URL */
   serverUrl?: string;
-  /** The app's own public base URL (e.g. https://my-app.base44.app). */
-  appBaseUrl?: string;
   /** Authentication token */
   token?: string;
 }

--- a/tests/unit/ai-gateway.test.ts
+++ b/tests/unit/ai-gateway.test.ts
@@ -25,43 +25,19 @@ describe("AI Gateway Module", () => {
       });
     });
 
-    test("should prefer appBaseUrl over serverUrl (domain-resolved gateway)", () => {
-      const base44 = createClient({
-        serverUrl,
-        appBaseUrl: "https://my-app.base44.app",
-        appId,
-      });
-      expect(base44.aiGateway.connection().baseURL).toBe(
-        "https://my-app.base44.app/api/ai/openai/v1"
-      );
-    });
-
-    test("should build from the Base44-App-Base-Url header in backend functions", () => {
+    test("should build from the Base44-Api-Url header in backend functions", () => {
       const request = new Request("https://functions.internal/run", {
         headers: {
           "Base44-App-Id": appId,
           "Base44-Api-Url": serverUrl,
-          "Base44-App-Base-Url": "https://my-app.base44.app",
           Authorization: "Bearer user-token",
         },
       });
       const base44 = createClientFromRequest(request);
       expect(base44.aiGateway.connection()).toEqual({
-        baseURL: "https://my-app.base44.app/api/ai/openai/v1",
+        baseURL,
         token: "user-token",
       });
-    });
-
-    test("should fall back to serverUrl when the app-base-url header is absent", () => {
-      const request = new Request("https://functions.internal/run", {
-        headers: {
-          "Base44-App-Id": appId,
-          "Base44-Api-Url": serverUrl,
-          Authorization: "Bearer user-token",
-        },
-      });
-      const base44 = createClientFromRequest(request);
-      expect(base44.aiGateway.connection().baseURL).toBe(baseURL);
     });
 
     test("should use the service-role token via asServiceRole", () => {


### PR DESCRIPTION
## What

Removes the `Base44-App-Base-Url` mechanism introduced in #214, before any release ships it (`aiGateway` is still unpublished — latest npm is 0.8.35):

- `createClientFromRequest` no longer reads the `Base44-App-Base-Url` header
- the AI gateway module no longer takes `appBaseUrl`; `connection()` builds its `baseURL` from `serverUrl` only (i.e. `Base44-Api-Url` inside backend functions)
- removed the `appBaseUrl`-preference tests; kept coverage for building from `Base44-Api-Url`

The **pre-existing** `appBaseUrl` client-config option (auth login/logout redirect URLs) is untouched.

## Why

The apper PR that would have injected `Base44-App-Base-Url` into function invocations ([base44-dev/apper#14868](https://github.com/base44-dev/apper/pull/14868)) was closed — the header will never exist on real invocations, so the SDK reading it is dead code.

Verified live instead that `Base44-Api-Url` already resolves to an app-recognized domain on the invocation paths that matter — published app traffic (same-origin), sandbox editor preview (`preview-sandbox--{app_id}.*` hosts are domain-resolved), and background workflows/automations (app-domain fallback) — so `serverUrl` is the right gateway origin. The one remaining gap (the builder's in-process test-function tool passes the builder host) is being fixed on the platform side, not in the SDK.

## Tests

`npm test`: 177 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)