### PR TITLE
fix: support React Native (window without document)

### DIFF
--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -10,7 +10,7 @@ import {
 } from "./analytics.types";
 import { getSharedInstance } from "../utils/sharedInstance.js";
 import type { AuthModule } from "./auth.types";
-import { generateUuid } from "../utils/common.js";
+import { generateUuid, isReactNative } from "../utils/common.js";
 
 export const USER_HEARTBEAT_EVENT_NAME = "__user_heartbeat_event__";
 export const ANALYTICS_INITIALIZATION_EVENT_NAME = "__initialization_event__";
@@ -70,7 +70,11 @@ export const createAnalyticsModule = ({
   // prevent overflow of events //
   const { maxQueueSize, throttleTime, batchSize } = analyticsSharedState.config;
 
-  if (!analyticsSharedState.config?.enabled) {
+  // Disable analytics on React Native. It defines `window` but not `document`,
+  // so the per-callsite `typeof window` guards below aren't enough to keep it
+  // from touching `document` (e.g. `document.referrer` on init). Node/SSR is
+  // still handled by those `window` guards, so this doesn't affect it.
+  if (!analyticsSharedState.config?.enabled || isReactNative) {
     return {
       track: () => {},
       cleanup: () => {},
@@ -328,7 +332,10 @@ async function getSessionContext(
 export function getAnalyticsConfigFromUrlParams():
   | AnalyticsModuleOptions
   | undefined {
-  if (typeof window === "undefined") return undefined;
+  // `window.location` is absent on React Native. This runs at module load (via
+  // the shared-state factory), so an unguarded `window.location.search` would
+  // throw on import there.
+  if (typeof window === "undefined" || !window.location) return undefined;
   const urlParams = new URLSearchParams(window.location.search);
   const analyticsEnable = urlParams.get(ANALYTICS_CONFIG_ENABLE_URL_PARAM_KEY);
 

--- a/src/utils/axios-client.ts
+++ b/src/utils/axios-client.ts
@@ -175,7 +175,9 @@ export function createAxiosClient({
 
   // Add origin URL in browser environment
   client.interceptors.request.use((config) => {
-    if (typeof window !== "undefined") {
+    // `window.location` is absent on React Native (where `window` still exists),
+    // so guard on it before reading `.href`.
+    if (typeof window !== "undefined" && window.location) {
       config.headers.set("X-Origin-URL", window.location.href);
       // On unauthenticated requests, attach a stable anonymous visitor id so the
       // backend can support anonymous agent access (conversation grouping + ownership).

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,12 @@
 export const isNode = typeof window === "undefined";
 export const isInIFrame = !isNode && window.self !== window.top;
 
+// React Native defines `window` (so `isNode` is false there) but not `document`.
+// Browser-only code paths gated on `window`/`isNode` alone would run — and crash —
+// on React Native. Node (no `window`) is already handled by those `window` guards;
+// this flags the window-without-a-DOM case that isn't.
+export const isReactNative = !isNode && typeof document === "undefined";
+
 export const generateUuid = () => {
   return (
     Math.random().toString(36).substring(2, 15) +

--- a/tests/unit/react-native.test.ts
+++ b/tests/unit/react-native.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// React Native defines a limited `window` polyfill but has no `document`,
+// `localStorage`, or `window.location`. The SDK must import, construct, and
+// make requests there without touching those globals. Analytics is disabled.
+describe("React Native environment", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  function stubReactNativeGlobals() {
+    // `window` exists but is a bare object: no `location`, no `addEventListener`,
+    // no `localStorage`.
+    vi.stubGlobal("window", {});
+    // `document` is not defined on React Native.
+    vi.stubGlobal("document", undefined);
+    vi.stubGlobal("localStorage", undefined);
+  }
+
+  test("importing and constructing the client does not throw", async () => {
+    stubReactNativeGlobals();
+    // Re-import so module-load code (e.g. the analytics shared-state factory)
+    // is evaluated against the React Native globals.
+    vi.resetModules();
+    const { createClient } = await import("../../src/index.ts");
+
+    const client = createClient({
+      serverUrl: "https://api.base44.com",
+      appId: "test-app-id",
+    });
+
+    expect(client.analytics).toBeDefined();
+    expect(() => client.cleanup()).not.toThrow();
+  });
+
+  test("analytics.track is a safe noop (no document access)", async () => {
+    stubReactNativeGlobals();
+    vi.resetModules();
+    const { createClient } = await import("../../src/index.ts");
+
+    const client = createClient({
+      serverUrl: "https://api.base44.com",
+      appId: "test-app-id",
+    });
+
+    expect(() =>
+      client.analytics.track({ eventName: "test-event" })
+    ).not.toThrow();
+
+    client.cleanup();
+  });
+
+  test("isReactNative reflects the window-without-document environment", async () => {
+    stubReactNativeGlobals();
+    vi.resetModules();
+    const { isReactNative, isNode } = await import("../../src/utils/common.ts");
+
+    expect(isNode).toBe(false);
+    expect(isReactNative).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the SDK import, construct, and make requests on React Native. RN defines a limited `window` polyfill but has no `document`, `localStorage`, or `window.location` — so the SDK's `typeof window === "undefined"` guards (which only tell Node/SSR apart from browser) passed in RN and then touched globals that aren't there.

Analytics is disabled on React Native for now (returns a noop module); the rest of the SDK works.

## Blockers fixed

1. **Import-time crash** — `analytics.ts` builds its shared state eagerly at module load, and the factory calls `getAnalyticsConfigFromUrlParams()` → `window.location.search`. Threw the moment the SDK was imported in RN. Now guarded with `!window.location`.
2. **Construction-time crash** — `createAnalyticsModule` runs `trackInitializationEvent` synchronously, reading `document.referrer` (optional chaining doesn't save an undeclared global → `ReferenceError`). The module now early-returns a noop `{ track, cleanup }` on RN.
3. **Per-request crash** — the axios request interceptor read `window.location.href` guarded only by `typeof window`. Now guarded with `&& window.location`.

## Design note

Gating is on a new `isReactNative = !isNode && typeof document === "undefined"` flag, **not** a plain "no document" check. The SDK's analytics runs headless in Node (queue + flush), and there are tests for it; gating on `document` alone would have disabled Node analytics too. `isReactNative` targets precisely the window-without-a-DOM case the existing guards miss.

## Known limitation

`getAnalyticsSessionId` falls back to a fresh UUID per call on RN (no `localStorage`), so the anonymous-visitor id isn't stable across requests there. It's try/catch-guarded so it won't crash, and authenticated flows use the token instead. A stable id on RN would need an injectable `AsyncStorage`-style persistence layer — out of scope here.

## Testing

- New `tests/unit/react-native.test.ts` (3 tests) stubs a window-without-`document` env, re-imports the SDK, and asserts import + construction + `analytics.track` don't throw (fails without the fixes).
- Full suite **167 passed**; typecheck, type-tests, build, and lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)