### PR TITLE
fix: drop uuid dependency so requests work on React Native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",
-        "socket.io-client": "^4.8.3",
-        "uuid": "^13.0.2"
+        "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
         "@types/hast": "^3.0.4",
@@ -5500,19 +5499,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "dependencies": {
     "axios": "^1.17.0",
-    "socket.io-client": "^4.8.3",
-    "uuid": "^13.0.2"
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@types/hast": "^3.0.4",

--- a/src/utils/axios-client.ts
+++ b/src/utils/axios-client.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
-import { isInIFrame } from "./common.js";
-import { v4 as uuidv4 } from "uuid";
+import { isInIFrame, generateUuid } from "./common.js";
 import { getAnalyticsSessionId } from "../modules/analytics.js";
 import type { Base44ErrorJSON } from "./axios-client.types.js";
 
@@ -186,7 +185,10 @@ export function createAxiosClient({
         config.headers.set("X-Base44-Anonymous-Id", getAnalyticsSessionId());
       }
     }
-    const requestId = uuidv4();
+    // Correlation id for the in-iframe request logging below; only needs to be
+    // unique, not cryptographically random. `uuid` would pull in
+    // `crypto.getRandomValues`, which React Native lacks, so use `generateUuid`.
+    const requestId = generateUuid();
     (config as any).requestId = requestId;
     if (isInIFrame) {
       try {

--- a/tests/unit/react-native.test.ts
+++ b/tests/unit/react-native.test.ts
@@ -59,4 +59,26 @@ describe("React Native environment", () => {
     expect(isNode).toBe(false);
     expect(isReactNative).toBe(true);
   });
+
+  test("requests succeed without crypto.getRandomValues", async () => {
+    stubReactNativeGlobals();
+    // React Native (Hermes) has no `crypto.getRandomValues`; the request
+    // interceptor's correlation id must not depend on it (the `uuid` lib does).
+    vi.stubGlobal("crypto", undefined);
+    vi.resetModules();
+    const { createAxiosClient } = await import(
+      "../../src/utils/axios-client.ts"
+    );
+
+    const client = createAxiosClient({ baseURL: "https://api.base44.com" });
+    let captured: any;
+    client.defaults.adapter = async (config) => {
+      captured = config;
+      return { data: {}, status: 200, statusText: "OK", headers: {}, config };
+    };
+
+    await expect(client.get("/health")).resolves.toBeDefined();
+    // The interceptor still attaches a unique correlation id.
+    expect(captured.requestId).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the React Native support work. `uuid` v13's `v4()` calls `crypto.getRandomValues()` internally, which React Native (Hermes) does not provide without the `react-native-get-random-values` polyfill — it throws `crypto.getRandomValues() not supported`. This ran on **every request** in the axios request interceptor (`axios-client.ts`), so all requests failed on React Native.

## Fix

- `uuid` was used in exactly one place: a `requestId` used only for in-iframe `postMessage` request/response correlation. It needs to be *unique*, not cryptographically random.
- Replaced `uuidv4()` with the existing `generateUuid()` (Math.random-based, in `common.ts`, already used for session/anonymous ids) — works in every environment.
- **Dropped the `uuid` dependency entirely** (package.json + lockfile), so the SDK no longer depends on `crypto.getRandomValues` and consumers don't need a polyfill.

## Testing

- New test drives a request with `crypto` stubbed to `undefined` (the RN condition) and asserts it resolves and still attaches a correlation id.
- Lockfile change is only the `uuid` removal.
- Full suite **168 passed**; typecheck, type-tests, build, and lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)