### PR TITLE
fix(sdk-ci): pin npm@11 for publish workflows (Node 20 runners)

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -48,7 +48,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -23,7 +23,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Why

The publish workflows run `npm install -g npm@latest` on **Node 20** runners. On **2026-07-08 ~21:06 UTC**, npm released **npm@12.0.0**, which requires Node `>=22`. So `@latest` now resolves to npm@12 and the step fails before anything else runs:

```
npm error code EBADENGINE
npm error Not compatible: npm@12.0.0
npm error Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

Nothing in the repo changed — the unpinned `@latest` swallowed an upstream breaking major. The last successful publish (2026-07-08 ~13:56 UTC) predated npm@12 by ~7 hours.

## What

Pin to **npm@11** — the newest npm that still supports Node 20 (`engines: ^20.17.0 || >=22.9`) — in both workflows:

- `preview-publish.yml` (PR preview publish — currently red on open PRs)
- `manual-publish.yml` (publish-on-dispatch — would fail the next real publish too)

Both files, because fixing only the preview would leave the actual publish broken.

## Validates itself

`preview-publish.yml` triggers on `pull_request`, so this PR runs its own pinned version — a green check here confirms the fix.

## Note

Pinning `npm@11` is the minimal fix. Longer term, bumping the runners to Node 22 would allow `npm@latest` again; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)