### PR TITLE
ci: Dependabot security-updates-only + 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,26 @@
+#
+# Switches js-sdk from routine version updates to SECURITY UPDATES ONLY, with a 7-day
+# cooldown — matching the vite-plugin / apper templates policy. (The previous config chased
+# every version bump with no cooldown, which created 11 non-security PRs.)
+#
+# open-pull-requests-limit: 0 turns off scheduled version bumps (no "chase latest" churn, no
+# major upgrades). Dependabot *security* updates ignore this limit and still flow — they need
+# Dependabot alerts enabled in repo Settings > Security. cooldown + groups are inert while
+# version updates are off, kept forward-compatible for if limit: 0 is ever dropped
+# (cooldown = 7-day supply-chain buffer; groups batch minor/patch).
 version: 2
 updates:
-  # Keep package.json dependencies patched. Combined with GitHub's
-  # Dependabot security updates (enabled in repo Settings > Security),
-  # this opens PRs for both routine version bumps and CVE fixes.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
     groups:
-      # Batch low-risk dev tooling updates into a single PR to cut noise.
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Keep the GitHub Actions used by these workflows up to date.
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+      npm-minor-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Why

The current Dependabot config chases **every** version bump with **no cooldown**, which produced 11 open non-security PRs. Switch to the org policy: **security updates only**, with a **7-day cooldown** (matching vite-plugin and the apper templates).

## What

Replaces `.github/dependabot.yml`:
- `open-pull-requests-limit: 0` → **no routine version-bump PRs** (no chase-latest, no majors).
- Dependabot **security** updates ignore that limit and still flow (need Dependabot alerts enabled in Settings → Security).
- `cooldown: default-days: 7` supply-chain buffer; `groups` batch minor/patch (both forward-compatible).

After this merges, the existing 11 version-bump PRs won't be recreated. `base44-dev/dependency-security-bot` analyzes the security PRs (root cause + CVE/GHSA, risk) and flags them to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)