### PR TITLE
Add SSO OIDC ID token retrieval

### DIFF
--- a/src/modules/sso.ts
+++ b/src/modules/sso.ts
@@ -20,5 +20,12 @@ export function createSsoModule(
       const url = `/apps/${appId}/auth/sso/accesstoken/${userid}`;
       return axios.get(url);
     },
+
+    // Get the stored SSO OIDC ID token for a specific user
+    async getIdToken(userid: string): Promise<string> {
+      const url = `/apps/${appId}/auth/sso/idtoken/${userid}`;
+      const response = await axios.get<string>(url);
+      return response as unknown as string;
+    },
   };
 }

--- a/src/modules/sso.ts
+++ b/src/modules/sso.ts
@@ -6,7 +6,6 @@ import { SsoModule } from "./sso.types";
  *
  * @param axios - Axios instance
  * @param appId - Application ID
- * @param userToken - User authentication token
  * @returns SSO module with authentication methods
  * @internal
  */
@@ -25,6 +24,8 @@ export function createSsoModule(
     async getIdToken(userid: string): Promise<string> {
       const url = `/apps/${appId}/auth/sso/idtoken/${userid}`;
       const response = await axios.get<string>(url);
+      // The configured response interceptor unwraps response.data at runtime,
+      // while AxiosInstance retains AxiosResponse typings.
       return response as unknown as string;
     },
   };

--- a/src/modules/sso.ts
+++ b/src/modules/sso.ts
@@ -21,12 +21,9 @@ export function createSsoModule(
     },
 
     // Get the stored SSO OIDC ID token for a specific user
-    async getIdToken(userid: string): Promise<string> {
+    async getIdToken(userid: string) {
       const url = `/apps/${appId}/auth/sso/idtoken/${userid}`;
-      const response = await axios.get<string>(url);
-      // The configured response interceptor unwraps response.data at runtime,
-      // while AxiosInstance retains AxiosResponse typings.
-      return response as unknown as string;
+      return axios.get(url);
     },
   };
 }

--- a/src/modules/sso.types.ts
+++ b/src/modules/sso.types.ts
@@ -1,5 +1,3 @@
-import { AxiosResponse } from "axios";
-
 /**
  * Response from SSO access token endpoint.
  * @internal

--- a/src/modules/sso.types.ts
+++ b/src/modules/sso.types.ts
@@ -11,9 +11,9 @@ export interface SsoAccessTokenResponse {
 /**
  * SSO (Single Sign-On) module for managing SSO authentication.
  *
- * This module provides methods for retrieving SSO access tokens for users.
- * These tokens allow you to authenticate Base44 users with external
- * systems or services.
+ * This module provides methods for retrieving SSO tokens for users. These
+ * tokens allow you to authenticate Base44 users with external systems or
+ * services.
  *
  * This module is only available to use with a client in service role authentication mode, which means it can only be used in backend environments.
  *
@@ -21,9 +21,15 @@ export interface SsoAccessTokenResponse {
  *
  * @example
  * ```typescript
- * // Access SSO module with service role
- * const response = await base44.asServiceRole.sso.getAccessToken('user_123');
- * console.log(response.data.access_token);
+ * import { createClientFromRequest } from 'npm:@base44/sdk';
+ *
+ * Deno.serve(async (req) => {
+ *   const base44 = createClientFromRequest(req);
+ *   const user = await base44.auth.me();
+ *   const idToken = await base44.asServiceRole.sso.getIdToken(user.id);
+ *
+ *   return Response.json({ idToken });
+ * });
  * ```
  */
 export interface SsoModule {
@@ -44,4 +50,16 @@ export interface SsoModule {
    * ```
    */
   getAccessToken(userid: string): Promise<SsoAccessTokenResponse>;
+
+  /**
+   * Gets the stored SSO OIDC ID token for the current app user.
+   *
+   * The service-role client must include an on-behalf-of token for the same
+   * user specified by `userid`. This method returns the stored token as-is and
+   * does not refresh it.
+   *
+   * @param userid - The current app user's ID.
+   * @returns Promise resolving to the raw ID-token string.
+   */
+  getIdToken(userid: string): Promise<string>;
 }

--- a/src/modules/sso.types.ts
+++ b/src/modules/sso.types.ts
@@ -21,15 +21,9 @@ export interface SsoAccessTokenResponse {
  *
  * @example
  * ```typescript
- * import { createClientFromRequest } from 'npm:@base44/sdk';
- *
- * Deno.serve(async (req) => {
- *   const base44 = createClientFromRequest(req);
- *   const user = await base44.auth.me();
- *   const idToken = await base44.asServiceRole.sso.getIdToken(user.id);
- *
- *   return Response.json({ idToken });
- * });
+ * // Access SSO module with service role
+ * const response = await base44.asServiceRole.sso.getAccessToken('user_123');
+ * console.log(response.data.access_token);
  * ```
  */
 export interface SsoModule {
@@ -60,6 +54,19 @@ export interface SsoModule {
    *
    * @param userid - The current app user's ID.
    * @returns Promise resolving to the raw ID-token string.
+   *
+   * @example
+   * ```typescript
+   * import { createClientFromRequest } from 'npm:@base44/sdk';
+   *
+   * Deno.serve(async (req) => {
+   *   const base44 = createClientFromRequest(req);
+   *   const user = await base44.auth.me();
+   *   const idToken = await base44.asServiceRole.sso.getIdToken(user.id);
+   *
+   *   return Response.json({ idToken });
+   * });
+   * ```
    */
   getIdToken(userid: string): Promise<string>;
 }

--- a/tests/unit/sso.test.ts
+++ b/tests/unit/sso.test.ts
@@ -41,6 +41,22 @@ describe("SSO module", () => {
     expect(scope.isDone()).toBe(true);
   });
 
+  test("getAccessToken issues the existing GET request and returns the raw token", async () => {
+    const rawAccessToken = "access-token-123";
+
+    scope
+      .get(`/api/apps/${appId}/auth/sso/accesstoken/${userId}`)
+      .reply(200, JSON.stringify(rawAccessToken), {
+        "Content-Type": "application/json",
+      });
+
+    const accessToken =
+      await base44.asServiceRole.sso.getAccessToken(userId);
+
+    expect(accessToken).toBe(rawAccessToken);
+    expect(scope.isDone()).toBe(true);
+  });
+
   test("getIdToken uses the service-role client with on-behalf-of authentication", async () => {
     scope
       .get(`/api/apps/${appId}/auth/sso/idtoken/${userId}`)

--- a/tests/unit/sso.test.ts
+++ b/tests/unit/sso.test.ts
@@ -41,20 +41,6 @@ describe("SSO module", () => {
     expect(scope.isDone()).toBe(true);
   });
 
-  test("getAccessToken keeps its existing request and return behavior", async () => {
-    const accessTokenResponse = { access_token: "access-token-123" };
-
-    scope
-      .get(`/api/apps/${appId}/auth/sso/accesstoken/${userId}`)
-      .reply(200, accessTokenResponse);
-
-    const response =
-      await base44.asServiceRole.sso.getAccessToken(userId);
-
-    expect(response).toEqual(accessTokenResponse);
-    expect(scope.isDone()).toBe(true);
-  });
-
   test("getIdToken uses the service-role client with on-behalf-of authentication", async () => {
     scope
       .get(`/api/apps/${appId}/auth/sso/idtoken/${userId}`)

--- a/tests/unit/sso.test.ts
+++ b/tests/unit/sso.test.ts
@@ -53,20 +53,41 @@ describe("SSO module", () => {
     const accessToken =
       await base44.asServiceRole.sso.getAccessToken(userId);
 
+    // Preserve the legacy public response type for compatibility while
+    // locking down the endpoint's existing raw-string runtime behavior.
     expect(accessToken).toBe(rawAccessToken);
     expect(scope.isDone()).toBe(true);
   });
 
   test("getIdToken uses the service-role client with on-behalf-of authentication", async () => {
+    const rawIdToken = "raw-id-token";
+
     scope
       .get(`/api/apps/${appId}/auth/sso/idtoken/${userId}`)
       .matchHeader("Authorization", `Bearer ${serviceToken}`)
       .matchHeader("on-behalf-of", `Bearer ${userToken}`)
-      .reply(200, JSON.stringify("raw-id-token"), {
+      .reply(200, JSON.stringify(rawIdToken), {
         "Content-Type": "application/json",
       });
 
-    await base44.asServiceRole.sso.getIdToken(userId);
+    const idToken = await base44.asServiceRole.sso.getIdToken(userId);
+
+    expect(idToken).toBe(rawIdToken);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test("getIdToken surfaces a 404 when no ID token is stored", async () => {
+    scope
+      .get(`/api/apps/${appId}/auth/sso/idtoken/${userId}`)
+      .reply(404, { detail: "No ID token stored", code: "NOT_FOUND" });
+
+    await expect(
+      base44.asServiceRole.sso.getIdToken(userId)
+    ).rejects.toMatchObject({
+      name: "Base44Error",
+      status: 404,
+      code: "NOT_FOUND",
+    });
 
     expect(scope.isDone()).toBe(true);
   });

--- a/tests/unit/sso.test.ts
+++ b/tests/unit/sso.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import nock from "nock";
+import { createClient } from "../../src/index.ts";
+
+describe("SSO module", () => {
+  const appId = "test-app-id";
+  const serverUrl = "https://base44.app";
+  const serviceToken = "service-token-123";
+  const userToken = "user-token-456";
+  const userId = "user_123";
+  let base44: ReturnType<typeof createClient>;
+  let scope: nock.Scope;
+
+  beforeEach(() => {
+    base44 = createClient({
+      serverUrl,
+      appId,
+      token: userToken,
+      serviceToken,
+    });
+    scope = nock(serverUrl);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("getIdToken issues the app-scoped GET request and returns the raw token", async () => {
+    const rawIdToken = "header.payload.signature";
+
+    scope
+      .get(`/api/apps/${appId}/auth/sso/idtoken/${userId}`)
+      .reply(200, JSON.stringify(rawIdToken), {
+        "Content-Type": "application/json",
+      });
+
+    const idToken: string =
+      await base44.asServiceRole.sso.getIdToken(userId);
+
+    expect(idToken).toBe(rawIdToken);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test("getAccessToken keeps its existing request and return behavior", async () => {
+    const accessTokenResponse = { access_token: "access-token-123" };
+
+    scope
+      .get(`/api/apps/${appId}/auth/sso/accesstoken/${userId}`)
+      .reply(200, accessTokenResponse);
+
+    const response =
+      await base44.asServiceRole.sso.getAccessToken(userId);
+
+    expect(response).toEqual(accessTokenResponse);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test("getIdToken uses the service-role client with on-behalf-of authentication", async () => {
+    scope
+      .get(`/api/apps/${appId}/auth/sso/idtoken/${userId}`)
+      .matchHeader("Authorization", `Bearer ${serviceToken}`)
+      .matchHeader("on-behalf-of", `Bearer ${userToken}`)
+      .reply(200, JSON.stringify("raw-id-token"), {
+        "Content-Type": "application/json",
+      });
+
+    await base44.asServiceRole.sso.getIdToken(userId);
+
+    expect(scope.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add `base44.asServiceRole.sso.getIdToken(userid)` for the app-scoped SSO OIDC ID-token endpoint
- return the backend's raw JSON string as a typed `Promise<string>`
- document backend-function usage and test the ID-token request, raw response, service-role authorization, and on-behalf-of authentication
- preserve `getAccessToken` implementation, signature, exported response type, and customer example while adding regression coverage for its existing raw-string runtime response

## Backend dependency

This SDK change depends on [apper PR #16698](https://github.com/base44-dev/apper/pull/16698).

The SDK method requires the backend endpoint from that PR to be deployed before it can succeed.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`
