### PR TITLE
docs: add Square to available connectors table

### DIFF
--- a/src/modules/connectors.types.ts
+++ b/src/modules/connectors.types.ts
@@ -121,6 +121,7 @@ export interface AppUserConnectorConnectionResponse {
  * | Slack Bot | `slackbot` |
  * | Snowflake | `snowflake` |
  * | Splitwise | `splitwise` |
+ * | Square | `square` |
  * | Supabase | `supabase` |
  * | TikTok | `tiktok` |
  * | Typeform | `typeform` |


### PR DESCRIPTION
## Summary

- Adds Square (`square`) to the Available connectors table in the SDK JSDoc (`connectors.types.ts`).

## Test plan

- [ ] Regenerate SDK docs and confirm Square appears in the published `connectors.mdx` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)