### PR TITLE
Update retired Anthropic model IDs in Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-20250514"
+          model: "claude-opus-4-8"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude-docs-drafter.yml
+++ b/.github/workflows/claude-docs-drafter.yml
@@ -37,7 +37,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
           claude_args: |
-            --model claude-sonnet-4-20250514
+            --model claude-sonnet-4-6
             --json-schema '{"type":"object","properties":{"needs_docs":{"type":"boolean","description":"true if the PR has public APIs that need new or improved JSDoc"}},"required":["needs_docs"]}'
 
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-20250514"
+          model: "claude-opus-4-8"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary

- replace `claude-opus-4-20250514` with `claude-opus-4-8` in the Claude review and interactive workflows
- replace `claude-sonnet-4-20250514` with `claude-sonnet-4-6` in the docs drafter workflow
- leave prompts, permissions, triggers, action versions, secrets, and all other workflow behavior unchanged

## Why

The Claude review workflow currently fails with a `404 not_found_error` for the retired `claude-opus-4-20250514` model:

- [Failing Actions job](https://github.com/base44/javascript-sdk/actions/runs/29822242893/job/88631707561)
- [Anthropic model-deprecation documentation](https://platform.claude.com/docs/en/about-claude/model-deprecations)

This replaces retired models with Anthropic's recommended successors.

## Validation

- parsed all three changed workflow files as YAML
- `git diff --check`
- `actionlint` was not available in the local environment
