### PR TITLE
fix: update Axios lockfile for security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1776,9 +1776,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.39",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.17.0",
+        "axios": "^1.18.1",
         "socket.io-client": "^4.8.3",
         "uuid": "^13.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "create-docs:process": "node scripts/mintlify-post-processing/file-processing/file-processing.js"
   },
   "dependencies": {
-    "axios": "^1.17.0",
+    "axios": "^1.18.1",
     "socket.io-client": "^4.8.3",
     "uuid": "^13.0.2"
   },


### PR DESCRIPTION
## Summary

- raise the direct Axios dependency range from `^1.17.0` to `^1.18.1` so published SDK consumers cannot resolve a vulnerable Axios release
- update the lockfile resolution from Axios `1.17.0` to `1.18.1`
- avoid unrelated dependency, source, formatting, and workflow changes

## Context

The production dependency audit currently fails on both:

- PR run: https://github.com/base44/javascript-sdk/actions/runs/29830541107/job/88633948306?pr=236
- `main` run: https://github.com/base44/javascript-sdk/actions/runs/29828398144

`npm audit --omit=dev --audit-level=high` reports multiple high-severity advisories against the directly installed `axios@1.17.0`. Axios `1.18.0` contains the fixes, but it is not available from the npm registry; `1.18.1` is the smallest available patched release.

## Dependency change

- Dependency: `axios` (direct production dependency)
- Old declared range: `^1.17.0`
- New declared range: `^1.18.1`
- Old resolved version: `1.17.0`
- New resolved version: `1.18.1`

Updating the declared lower bound is necessary because consumers of the published SDK do not use this repository's lockfile.

## Validation

- `npm ci` — passed in the Security Audit, Unit Tests, and Lint workflows
- `npm audit --omit=dev --audit-level=high` — passed; `found 0 vulnerabilities`
- `npm run test:unit` — passed
- `npm run lint` — passed
- `npm run build` (`tsc`) — passed in the preview workflow
- `git diff --check` — passed
- final dependency/lockfile diff review — passed; only the Axios declaration and Axios lockfile metadata changed

Checks: https://github.com/base44/javascript-sdk/pull/237/checks

## Remaining audit findings

The report-only full `npm audit` still reports 2 high-severity dev-only findings:

- `brace-expansion` (`GHSA-3jxr-9vmj-r5cp`)
- `js-yaml` (`GHSA-52cp-r559-cp3m`)

They do not affect `npm audit --omit=dev` and are intentionally outside this focused production Axios remediation.
