### PR TITLE
docs(sso): expose SSO module in the generated SDK reference

### DIFF
--- a/src/client.types.ts
+++ b/src/client.types.ts
@@ -144,9 +144,7 @@ export interface Base44Client {
     functions: FunctionsModule;
     /** {@link IntegrationsModule | Integrations module} with elevated permissions. */
     integrations: IntegrationsModule;
-    /** {@link SsoModule | SSO module} for generating SSO tokens.
-     * @internal
-     */
+    /** {@link SsoModule | SSO module} for generating SSO tokens. */
     sso: SsoModule;
     /** Cleanup function to disconnect WebSocket connections. */
     cleanup: () => void;

--- a/src/modules/sso.types.ts
+++ b/src/modules/sso.types.ts
@@ -1,6 +1,5 @@
 /**
  * Response from SSO access token endpoint.
- * @internal
  */
 export interface SsoAccessTokenResponse {
   access_token: string;
@@ -14,8 +13,6 @@ export interface SsoAccessTokenResponse {
  * services.
  *
  * This module is only available to use with a client in service role authentication mode, which means it can only be used in backend environments.
- *
- * @internal
  *
  * @example
  * ```typescript
@@ -55,6 +52,7 @@ export interface SsoModule {
    *
    * @example
    * ```typescript
+   * // Get the user's ID token to read identity claims such as email
    * import { createClientFromRequest } from 'npm:@base44/sdk';
    *
    * Deno.serve(async (req) => {

--- a/src/modules/sso.types.ts
+++ b/src/modules/sso.types.ts
@@ -13,41 +13,49 @@ export interface SsoAccessTokenResponse {
  * services.
  *
  * This module is only available to use with a client in service role authentication mode, which means it can only be used in backend environments.
- *
- * @example
- * ```typescript
- * // Access SSO module with service role
- * const response = await base44.asServiceRole.sso.getAccessToken('user_123');
- * console.log(response.data.access_token);
- * ```
  */
 export interface SsoModule {
   /**
-   * Gets SSO access token for a specific user.
+   * Gets an SSO access token for the user who made the current request.
    *
-   * Retrieves a Single Sign-On access token that can be used to authenticate
-   * a user with external services or systems.
+   * Use this token to authenticate the user with external systems or services.
+   * This only works for that same user. Create the client with
+   * {@link createClientFromRequest} so it acts on behalf of the request's user,
+   * then pass that user's ID as `userid`. If `userid` is any other user, the
+   * call fails. An expired token is refreshed automatically when a refresh token
+   * is available.
    *
-   * @param userid - The user ID to get the access token for.
+   * @param userid - The ID of the user who made the current request, such as the
+   * `id` returned by {@link AuthModule | base44.auth.me()}.
    * @returns Promise resolving to the SSO access token response.
    *
    * @example
    * ```typescript
-   * // Get SSO access token for a user
-   * const response = await base44.asServiceRole.sso.getAccessToken('user_123');
-   * console.log(response.access_token);
+   * // Get the user's SSO access token to call an external system
+   * import { createClientFromRequest } from 'npm:@base44/sdk';
+   *
+   * Deno.serve(async (req) => {
+   *   const base44 = createClientFromRequest(req);
+   *   const user = await base44.auth.me();
+   *   const { access_token } = await base44.asServiceRole.sso.getAccessToken(user.id);
+   *
+   *   return Response.json({ access_token });
+   * });
    * ```
    */
   getAccessToken(userid: string): Promise<SsoAccessTokenResponse>;
 
   /**
-   * Gets the stored SSO OIDC ID token for the current app user.
+   * Gets the stored SSO OIDC ID token for the user who made the current request.
    *
-   * The service-role client must include an on-behalf-of token for the same
-   * user specified by `userid`. This method returns the stored token as-is and
-   * does not refresh it.
+   * This only works for that same user, not for arbitrary users. Create the
+   * client with {@link createClientFromRequest} so it acts on behalf of the
+   * request's user, then pass that user's ID as `userid`. If `userid` is any
+   * other user, the call fails. The stored token is returned as-is and is never
+   * refreshed, so the call fails if the token has already expired.
    *
-   * @param userid - The current app user's ID.
+   * @param userid - The ID of the user who made the current request, such as the
+   * `id` returned by {@link AuthModule | base44.auth.me()}.
    * @returns Promise resolving to the raw ID-token string.
    *
    * @example


### PR DESCRIPTION
## Summary

The SSO module (`getAccessToken`, `getIdToken`) has complete JSDoc but was marked `@internal`, so it never appeared on the generated SDK reference site. This removes `@internal` from the `SsoModule` interface and `SsoAccessTokenResponse` so the module is included in doc generation.

- Remove `@internal` from `SsoModule` and `SsoAccessTokenResponse` in `src/modules/sso.types.ts`
- Add a leading comment to the `getIdToken` `@example` so the generator renders the `import` inside the code block instead of hoisting it into the code-group title

## Why

`getIdToken` was added in #234 and shipped in 0.8.40, but because the whole module carries `@internal`, TypeDoc drops it during generation and neither SSO method shows up in the reference docs. The only public trace of it was in the agent-facing skills docs, which is the wrong place for SDK reference content.

## Note

This un-hides the **whole** SSO module, so `getAccessToken` is published alongside `getIdToken`. That's intentional (they're the module's two methods) but it is a deliberate "make SSO public in the reference" decision worth a look.

## Validation

- `npm run build` passes (tsc)
- `npm test -- sso.test` passes (4/4)
- `npm run create-docs` generates `interfaces/sso.mdx` correctly

The paired mintlify-docs PR with the regenerated reference page: base44-dev/mintlify-docs#expose-sso-module

🤖 Generated with [Claude Code](https://claude.com/claude-code)