### PR TITLE
fix(auth): carry app_id in redirectToLogin from foreign origins

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -6,6 +6,7 @@ import {
   ChangePasswordParams,
   ResetPasswordParams,
 } from "./auth.types";
+import { getLoginUrl } from "../utils/auth-utils.js";
 
 function isInsideIframe(): boolean {
   if (typeof window === "undefined") return false;
@@ -116,8 +117,11 @@ export function createAuthModule(
         ? new URL(nextUrl, window.location.origin).toString()
         : window.location.href;
 
-      // Build the login URL
-      const loginUrl = `${options.appBaseUrl}/login?from_url=${encodeURIComponent(redirectUrl)}`;
+      // A foreign origin (e.g. local dev) can't resolve the app by Host, so
+      // the login URL must carry the app id; same-origin keeps the bare path.
+      const loginUrl = options.appBaseUrl
+        ? getLoginUrl(redirectUrl, { serverUrl: options.appBaseUrl, appId })
+        : `/login?from_url=${encodeURIComponent(redirectUrl)}`;
 
       // Redirect to the login page
       window.location.href = loginUrl;

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -219,6 +219,23 @@ describe('Auth Module', () => {
       global.window = originalWindow;
     });
 
+    test('should preserve a query string in nextUrl through from_url encoding', () => {
+      const originalWindow = global.window;
+      const mockLocation = { href: '' };
+      global.window = {
+        location: mockLocation
+      };
+
+      const nextUrl = 'https://example.com/dashboard?tab=x&page=2';
+      base44.auth.redirectToLogin(nextUrl);
+
+      expect(mockLocation.href).toBe(
+        `${appBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}&app_id=${appId}`
+      );
+
+      global.window = originalWindow;
+    });
+
     test('should use relative URL for login redirect when appBaseUrl is not provided', () => {
       // Create a client without appBaseUrl
       const clientWithoutAppBaseUrl = createClient({

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -165,7 +165,7 @@ describe('Auth Module', () => {
 
       // Verify the redirect URL was set correctly
       expect(mockLocation.href).toBe(
-        `${appBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}`
+        `${appBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}&app_id=${appId}`
       );
 
       // Restore window
@@ -185,7 +185,7 @@ describe('Auth Module', () => {
 
       // Verify the redirect URL uses current URL
       expect(mockLocation.href).toBe(
-        `${appBaseUrl}/login?from_url=${encodeURIComponent(currentUrl)}`
+        `${appBaseUrl}/login?from_url=${encodeURIComponent(currentUrl)}&app_id=${appId}`
       );
 
       // Restore window
@@ -212,7 +212,7 @@ describe('Auth Module', () => {
 
       // Verify the redirect URL uses the custom appBaseUrl
       expect(mockLocation.href).toBe(
-        `${customAppBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}`
+        `${customAppBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}&app_id=${appId}`
       );
 
       // Restore window

--- a/tests/unit/client.test.js
+++ b/tests/unit/client.test.js
@@ -98,7 +98,7 @@ describe('appBaseUrl Normalization', () => {
 
     // Verify the redirect URL uses the custom appBaseUrl
     expect(mockLocation.href).toBe(
-      `${customAppBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}`
+      `${customAppBaseUrl}/login?from_url=${encodeURIComponent(nextUrl)}&app_id=test-app-id`
     );
 
     // Restore window


### PR DESCRIPTION
## Problem

`redirectToLogin` builds `${appBaseUrl}/login?from_url=...` with no app identity. In production (`appBaseUrl === ''`) the relative `/login` resolves the app by Host, so it works. In local dev, where the vite-plugin injects an absolute `appBaseUrl` (e.g. `https://base44.app` for standalone `npm run dev`), the redirect lands on the apex host, which cannot resolve the app → 404 "App not found".

## Fix

When `appBaseUrl` is a non-empty absolute origin, build the login URL with the existing `getLoginUrl` util so it carries `app_id`:

```
${appBaseUrl}/login?from_url=<encoded absolute URL>&app_id=<appId>
```

When `appBaseUrl === ''` (production/published/custom domains), the emitted URL stays **byte-identical** to today's (`/login?from_url=...`) — no behavior change on working paths.

## Cross-repo context

This is the SDK half of a two-PR feature (option A of the login-redirect decision):
- **apper PR (counterpart, in flight)**: apex `/login?app_id=` resolution + `UserAppMain` app_id fallback + AppLogin `from_url` localhost carve-out. The round-trip to a local dev origin only completes once both halves land.
- Under `base44 dev`, the CLI dev-server `/login` carve-out forwards the full query string verbatim, so the same URL serves both dev modes.
- OAuth state shape converges on what `loginWithProvider` already emits (verified round-tripping from localhost).

## Tests

- Updated the three absolute-`appBaseUrl` expectations in `tests/unit/auth.test.js` and `tests/unit/client.test.js` to assert the appended `app_id`.
- The relative-path test (`appBaseUrl` absent) is untouched and asserts the exact legacy string — the byte-identical guard.
- Full suite: 187/187 green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)