### PR TITLE
feat(auth): PKCE session-code handoff for SSO logins (apper#17216 §5.2)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,7 @@ import {
   createUserConnectorsModule,
 } from "./modules/connectors.js";
 import { getAccessToken } from "./utils/auth-utils.js";
+import { redeemSessionHandoffCode } from "./utils/session-handoff.js";
 import { createFunctionsModule } from "./modules/functions.js";
 import { createAgentsModule } from "./modules/agents.js";
 import { createAiGatewayModule } from "./modules/ai-gateway.js";
@@ -158,10 +159,31 @@ export function createClient(config: CreateClientConfig): Base44Client {
   // requests during construction (notably analytics, which fires an init
   // event whose flush calls auth.me()). Without this, the first User/me
   // request is built before setToken runs and goes out unauthenticated.
+  //
+  // Precedence: an explicit config token wins (legacy behavior); then a PKCE
+  // session-code handoff in the URL (base44-dev/apper#17216 §5.2) — the user
+  // just completed a login, so it outranks any stored token, mirroring how
+  // getAccessToken prefers a URL access_token over localStorage; then the
+  // legacy capture. When the server spoke legacy — including after a backend
+  // rollback — redeemSessionHandoffCode() returns null synchronously and the
+  // legacy capture below runs unchanged.
+  let tokenBootstrap: Promise<void> | null = null;
   if (typeof window !== "undefined") {
-    const accessToken = token || getAccessToken();
-    if (accessToken) {
-      userAuthModule.setToken(accessToken);
+    const sessionExchange = token ? null : redeemSessionHandoffCode();
+    if (sessionExchange) {
+      tokenBootstrap = sessionExchange.then((exchangedToken) => {
+        // On exchange failure, fall back to any stored token rather than
+        // leaving auth state empty (same fallback getAccessToken applies).
+        const accessToken = exchangedToken || getAccessToken();
+        if (accessToken) {
+          userAuthModule.setToken(accessToken);
+        }
+      });
+    } else {
+      const accessToken = token || getAccessToken();
+      if (accessToken) {
+        userAuthModule.setToken(accessToken);
+      }
     }
   }
 
@@ -265,6 +287,13 @@ export function createClient(config: CreateClientConfig): Base44Client {
     // We perform this check asynchronously to not block client creation
     setTimeout(async () => {
       try {
+        // A pending session-code exchange must settle before the auth probe.
+        // Probing early would see no token, redirect to login, and abandon
+        // the in-flight exchange — minting a fresh code on every round, i.e.
+        // a login loop (the exact BUG-787 failure shape).
+        if (tokenBootstrap) {
+          await tokenBootstrap;
+        }
         const isAuthenticated = await userModules.auth.isAuthenticated();
         if (!isAuthenticated) {
           userModules.auth.redirectToLogin(window.location.href);

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -8,6 +8,7 @@ import {
   ResetPasswordParams,
 } from "./auth.types";
 import { resetAnalyticsSessionContext } from "./analytics.js";
+import { prepareSessionHandoffKickoff } from "../utils/session-handoff.js";
 
 function isInsideIframe(): boolean {
   if (typeof window === "undefined") return false;
@@ -179,10 +180,32 @@ export function createAuthModule(
       const loginUrl = `${options.appBaseUrl}/api${authPath}?${queryParams}`;
 
       // When running inside an iframe, use a popup to avoid OAuth providers
-      // blocking iframe navigation.
+      // blocking iframe navigation. Popups stay on the exact legacy kickoff:
+      // they deliver the token via postMessage and never redeem a code (the
+      // backend skips the code mint when popup_origin is present).
       if (isInsideIframe()) {
         const popupLoginUrl = `${loginUrl}&popup_origin=${encodeURIComponent(window.location.origin)}`;
         return loginViaPopup(popupLoginUrl, redirectUrl, window.location.origin);
+      }
+
+      // Full-page SSO redirect: offer the PKCE session-code handoff
+      // (base44-dev/apper#17216 §5.2). The backend decides per request whether
+      // to use it; a server that answers with the legacy ?access_token= —
+      // including after a backend rollback — is honored unchanged at
+      // redemption. If PKCE can't be prepared locally, kick off with the
+      // unmodified legacy URL (version=2 without a valid challenge is a 400
+      // at /login, so it's all-or-nothing).
+      if (provider === "sso") {
+        prepareSessionHandoffKickoff()
+          .then((pkceQuery) => {
+            window.location.href = pkceQuery
+              ? `${loginUrl}${pkceQuery}`
+              : loginUrl;
+          })
+          .catch(() => {
+            window.location.href = loginUrl;
+          });
+        return;
       }
 
       // Default: full-page redirect

--- a/src/utils/session-handoff.ts
+++ b/src/utils/session-handoff.ts
@@ -1,0 +1,206 @@
+/**
+ * PKCE-bound one-time session-code handoff for SSO logins
+ * (base44-dev/apper#17216 §5.2).
+ *
+ * The SDK OFFERS the handoff at login kickoff (`version=2` + S256
+ * `code_challenge`) and the backend DECIDES per request: it only emits a
+ * `session_code` when every server-side gate holds (verified custom domain,
+ * non-private app, feature flag ON). In every other case — older backends,
+ * excluded apps, and critically a BACKEND ROLLBACK — the server keeps
+ * delivering the legacy `?access_token=` URL param, which the SDK digests
+ * exactly as before. This is a negotiation, never a deprecation: the legacy
+ * path must keep working here forever.
+ *
+ * Fail-open rule for kickoff: never send `version=2` unless this browser can
+ * actually complete the exchange (WebCrypto, sessionStorage that persists,
+ * fetch). The server 400s a `version=2` login without a valid challenge, and
+ * an opted-in login whose verifier is lost can never redeem its code — both
+ * are avoided by simply not opting in and letting the legacy path run.
+ */
+
+/** sessionStorage key for the PKCE verifier. Per-tab by design (RFC 7636: the
+ * verifier never leaves the browser); a login that completes in a different
+ * tab loses it — a named, expected failure mode, see redeemSessionHandoffCode. */
+export const PKCE_VERIFIER_STORAGE_KEY = "base44_pkce_verifier";
+
+/** Server-side format for challenge/verifier: base64url of 32 bytes, 43 chars. */
+const BASE64URL_43 = /^[A-Za-z0-9_-]{43}$/;
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Prepares the PKCE opt-in for an SSO login kickoff.
+ *
+ * Generates a verifier, persists it in sessionStorage (verified by read-back —
+ * a write that doesn't stick means the exchange could never succeed), and
+ * returns the query-string suffix to append to the login URL:
+ * `&version=2&code_challenge=<S256>&code_challenge_method=S256`.
+ *
+ * Returns `null` on ANY failure or missing capability, in which case the
+ * caller must use the unmodified legacy login URL. Never throws.
+ *
+ * @internal
+ */
+export async function prepareSessionHandoffKickoff(): Promise<string | null> {
+  try {
+    if (typeof window === "undefined") return null;
+
+    const crypto = globalThis.crypto;
+    if (!crypto?.getRandomValues || !crypto.subtle?.digest) return null;
+    // The exchange at redemption time needs fetch; don't opt in without it.
+    if (typeof fetch !== "function") return null;
+
+    const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
+
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(verifier)
+    );
+    const challenge = base64UrlEncode(new Uint8Array(digest));
+    // The server rejects a malformed opt-in with a 400 at /login; a malformed
+    // challenge here must therefore mean "don't opt in", never "send anyway".
+    if (!BASE64URL_43.test(challenge)) return null;
+
+    // Store last, after everything else succeeded, and verify the write took
+    // (sandboxed iframes and lockdown modes can throw OR silently drop it).
+    window.sessionStorage.setItem(PKCE_VERIFIER_STORAGE_KEY, verifier);
+    if (window.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY) !== verifier) {
+      return null;
+    }
+
+    return `&version=2&code_challenge=${challenge}&code_challenge_method=S256`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Redeems a PKCE session-code handoff from the current URL, if one is present.
+ *
+ * Returns `null` synchronously when the URL carries no handoff — including
+ * when it carries a legacy `?access_token=` (the legacy capture wins outright;
+ * this is what makes a backend rollback safe). Otherwise strips the handoff
+ * params from the URL immediately and returns a promise resolving to the
+ * exchanged access token, or `null` when the exchange fails. Never rejects,
+ * never redirects: a failed exchange leaves the app unauthenticated and lets
+ * its normal login flow take over (each retry mints a fresh code, so this
+ * self-heals rather than looping).
+ *
+ * @internal
+ */
+export function redeemSessionHandoffCode(): Promise<string | null> | null {
+  if (typeof window === "undefined" || !window.location) return null;
+
+  let code: string | null = null;
+  let exchangePath: string | null = null;
+  let urlParams: URLSearchParams;
+  try {
+    urlParams = new URLSearchParams(window.location.search);
+    code = urlParams.get("session_code");
+    exchangePath = urlParams.get("session_exchange_path");
+    if (!code || !exchangePath) return null;
+    // A server speaking legacy is authoritative: if an access_token is in the
+    // URL (the two are never both sent by a real backend), take the legacy
+    // path and ignore the code entirely.
+    if (urlParams.get("access_token")) return null;
+
+    // Strip the one-time params right away so the code doesn't linger in the
+    // URL/history or get re-submitted on reload. `is_new_user` stays in the
+    // URL exactly as the legacy flow leaves it.
+    urlParams.delete("session_code");
+    urlParams.delete("session_exchange_path");
+    const newUrl = `${window.location.pathname}${
+      urlParams.toString() ? `?${urlParams.toString()}` : ""
+    }${window.location.hash}`;
+    window.history.replaceState(
+      {},
+      typeof document !== "undefined" ? document.title : "",
+      newUrl
+    );
+  } catch (e) {
+    console.error("Error reading session handoff params from URL:", e);
+    return null;
+  }
+
+  return exchangeSessionHandoffCode(code, exchangePath);
+}
+
+async function exchangeSessionHandoffCode(
+  code: string,
+  exchangePath: string
+): Promise<string | null> {
+  // The verifier is one-shot: take it out of storage no matter how the
+  // exchange ends (a failed PKCE check doesn't burn the code server-side,
+  // but a stale verifier can never match a future login's challenge).
+  let verifier: string | null = null;
+  try {
+    verifier = window.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY);
+    if (verifier !== null) {
+      window.sessionStorage.removeItem(PKCE_VERIFIER_STORAGE_KEY);
+    }
+  } catch {
+    verifier = null;
+  }
+
+  // SECURITY: the exchange path arrives via the URL, so treat it as tainted.
+  // POSTing the code + verifier to an attacker-chosen origin would hand over
+  // both halves of the PKCE proof — enforce same-origin, path-only semantics.
+  let exchangeUrl: URL;
+  try {
+    exchangeUrl = new URL(exchangePath, window.location.origin);
+  } catch {
+    console.error("Invalid session_exchange_path; skipping token exchange.");
+    return null;
+  }
+  if (exchangeUrl.origin !== window.location.origin) {
+    console.error(
+      "Cross-origin session_exchange_path rejected; skipping token exchange."
+    );
+    return null;
+  }
+
+  if (typeof fetch !== "function") return null;
+
+  try {
+    const response = await fetch(exchangeUrl.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        code,
+        ...(verifier ? { code_verifier: verifier } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      if (!verifier) {
+        // Named failure mode (base44-dev/apper#17216): the login completed in
+        // a different tab/window than it started in, so the per-tab PKCE
+        // verifier is gone and the server fails closed. Logging in again from
+        // this tab works.
+        console.warn(
+          "Base44 SDK: SSO login could not be completed because it finished " +
+            "in a different browser tab than it started in (missing PKCE " +
+            "verifier). Please log in again."
+        );
+      } else {
+        console.error(
+          `Base44 SDK: SSO session-code exchange failed (HTTP ${response.status}).`
+        );
+      }
+      return null;
+    }
+
+    const data = await response.json();
+    const accessToken = data?.access_token;
+    return typeof accessToken === "string" && accessToken ? accessToken : null;
+  } catch (e) {
+    console.error("Base44 SDK: SSO session-code exchange failed:", e);
+    return null;
+  }
+}

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -770,16 +770,22 @@ describe('Auth Module', () => {
       global.window = originalWindow;
     });
 
-    test('should use SSO URL structure for sso provider', () => {
+    test('should use SSO URL structure for sso provider', async () => {
       const originalWindow = global.window;
       const mockLocation = { href: '', origin: 'https://myapp.com' };
       const win = { location: mockLocation };
       win.parent = win;
       global.window = win;
 
+      // SSO kickoff is async since the PKCE opt-in (#17216 §5.2): the
+      // navigation happens after the (attempted) challenge preparation. This
+      // window stub has no sessionStorage, so PKCE prep fails and the kickoff
+      // falls back to the exact legacy URL — no version=2 opt-in.
       base44.auth.loginWithProvider('sso', '/dashboard');
-
-      expect(mockLocation.href).toContain(`/api/apps/${appId}/auth/sso/login?`);
+      await vi.waitFor(() =>
+        expect(mockLocation.href).toContain(`/api/apps/${appId}/auth/sso/login?`)
+      );
+      expect(mockLocation.href).not.toContain('version=2');
 
       global.window = originalWindow;
     });

--- a/tests/unit/session-handoff.test.ts
+++ b/tests/unit/session-handoff.test.ts
@@ -1,0 +1,484 @@
+/**
+ * PKCE session-code handoff (base44-dev/apper#17216 §5.2).
+ *
+ * The invariant under test throughout: the SDK OFFERS version=2 and the
+ * backend DECIDES. Whatever the server answers with — a session_code or the
+ * legacy ?access_token= (including after a backend rollback) — the SDK
+ * digests it. Legacy is never deprecated, and the SDK never opts in to a
+ * handoff this browser can't complete.
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { createHash } from "node:crypto";
+import nock from "nock";
+import {
+  prepareSessionHandoffKickoff,
+  redeemSessionHandoffCode,
+  PKCE_VERIFIER_STORAGE_KEY,
+} from "../../src/utils/session-handoff.ts";
+import { createClient } from "../../src/index.ts";
+
+const APP_ORIGIN = "https://myapp.example.com";
+const SERVER_URL = "https://api.base44.com";
+const APP_ID = "test-app-id";
+const EXCHANGE_PATH = `/api/apps/${APP_ID}/auth/sso/exchange`;
+const VERIFIER_43 = "v".repeat(43);
+
+function makeStorage(overrides: Record<string, unknown> = {}) {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    ...overrides,
+  };
+}
+
+function installWindow({
+  search = "",
+  pathname = "/Dashboard",
+  hash = "",
+  sessionStorage = makeStorage(),
+  localStorage = makeStorage(),
+  iframe = false,
+}: {
+  search?: string;
+  pathname?: string;
+  hash?: string;
+  sessionStorage?: unknown;
+  localStorage?: ReturnType<typeof makeStorage>;
+  iframe?: boolean;
+} = {}) {
+  const win: any = {
+    location: {
+      search,
+      pathname,
+      hash,
+      origin: APP_ORIGIN,
+      href: `${APP_ORIGIN}${pathname}${search}${hash}`,
+    },
+    history: { replaceState: vi.fn() },
+    sessionStorage,
+    localStorage,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    open: vi.fn(() => null),
+    screenX: 0,
+    screenY: 0,
+    outerWidth: 1024,
+    outerHeight: 768,
+  };
+  win.parent = iframe ? {} : win;
+  vi.stubGlobal("window", win);
+  vi.stubGlobal("document", {
+    title: "Test",
+    referrer: "",
+    visibilityState: "visible",
+  });
+  vi.stubGlobal("localStorage", localStorage);
+  return win;
+}
+
+function stubFetch(impl?: (...args: any[]) => Promise<any>) {
+  const fetchMock = vi.fn(
+    impl ??
+      (async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fresh-jwt" }),
+      }))
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function sha256Base64Url(input: string): string {
+  return createHash("sha256").update(input).digest("base64url");
+}
+
+function handoffSearch({
+  code = "the-code",
+  path = EXCHANGE_PATH,
+  extra = "",
+}: { code?: string; path?: string; extra?: string } = {}) {
+  return `?session_code=${code}&session_exchange_path=${encodeURIComponent(path)}${extra}`;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  nock.cleanAll();
+});
+
+describe("prepareSessionHandoffKickoff", () => {
+  test("returns version=2 + S256 challenge and stores the verifier", async () => {
+    const win = installWindow();
+
+    const suffix = await prepareSessionHandoffKickoff();
+
+    expect(suffix).toMatch(
+      /^&version=2&code_challenge=[A-Za-z0-9_-]{43}&code_challenge_method=S256$/
+    );
+    const verifier = win.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY);
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    // RFC 7636: challenge = BASE64URL(SHA256(ASCII(verifier))), and the
+    // verifier itself never appears in the kickoff URL.
+    const challenge = suffix!.match(/code_challenge=([A-Za-z0-9_-]{43})/)![1];
+    expect(challenge).toBe(sha256Base64Url(verifier!));
+    expect(suffix).not.toContain(verifier);
+  });
+
+  test("generates a fresh verifier for every kickoff", async () => {
+    const win = installWindow();
+    await prepareSessionHandoffKickoff();
+    const first = win.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY);
+    await prepareSessionHandoffKickoff();
+    const second = win.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY);
+    expect(first).not.toBe(second);
+  });
+
+  test("fails open to legacy when sessionStorage access throws", async () => {
+    installWindow({
+      sessionStorage: {
+        setItem: () => {
+          throw new Error("sandboxed");
+        },
+      },
+    });
+    expect(await prepareSessionHandoffKickoff()).toBeNull();
+  });
+
+  test("fails open when the verifier write does not stick", async () => {
+    // Some lockdown modes drop writes silently instead of throwing; an
+    // opted-in login whose verifier is gone could never redeem its code.
+    installWindow({
+      sessionStorage: makeStorage({ setItem: () => {} }),
+    });
+    expect(await prepareSessionHandoffKickoff()).toBeNull();
+  });
+
+  test("fails open when WebCrypto is unavailable", async () => {
+    installWindow();
+    vi.stubGlobal("crypto", {});
+    expect(await prepareSessionHandoffKickoff()).toBeNull();
+  });
+
+  test("fails open outside a browser", async () => {
+    expect(await prepareSessionHandoffKickoff()).toBeNull();
+  });
+});
+
+describe("loginWithProvider kickoff negotiation", () => {
+  function makeAuthClient() {
+    // Created windowless (node) so the browser bootstrap in createClient is
+    // inert; loginWithProvider reads window at call time.
+    return createClient({
+      serverUrl: SERVER_URL,
+      appId: APP_ID,
+      appBaseUrl: APP_ORIGIN,
+    });
+  }
+
+  test("sso kickoff appends version=2 + challenge when PKCE is available", async () => {
+    const client = makeAuthClient();
+    const win = installWindow();
+
+    client.auth.loginWithProvider("sso", "/dashboard");
+
+    await vi.waitFor(() =>
+      expect(win.location.href).toContain(`/api/apps/${APP_ID}/auth/sso/login?`)
+    );
+    expect(win.location.href).toContain("&version=2&code_challenge=");
+    expect(win.location.href).toContain("&code_challenge_method=S256");
+    const challenge = win.location.href.match(
+      /code_challenge=([A-Za-z0-9_-]{43})/
+    )![1];
+    expect(challenge).toBe(
+      sha256Base64Url(win.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY)!)
+    );
+  });
+
+  test("sso kickoff falls back to the exact legacy URL when PKCE prep fails", async () => {
+    const client = makeAuthClient();
+    const win = installWindow({
+      sessionStorage: makeStorage({ setItem: () => {} }),
+    });
+
+    client.auth.loginWithProvider("sso", "/dashboard");
+
+    await vi.waitFor(() =>
+      expect(win.location.href).toContain(`/api/apps/${APP_ID}/auth/sso/login?`)
+    );
+    expect(win.location.href).not.toContain("version=2");
+    expect(win.location.href).not.toContain("code_challenge");
+  });
+
+  test("non-sso providers keep the synchronous legacy kickoff", () => {
+    const client = makeAuthClient();
+    const win = installWindow();
+
+    client.auth.loginWithProvider("google", "/dashboard");
+
+    expect(win.location.href).toContain("/api/apps/auth/login?");
+    expect(win.location.href).not.toContain("version=2");
+    expect(win.location.href).not.toContain("code_challenge");
+  });
+
+  test("popup (iframe) kickoff stays on the exact legacy URL", () => {
+    // Popups deliver via postMessage and never redeem a code; the backend
+    // skips the code mint for them. Their kickoff must stay byte-identical.
+    const client = makeAuthClient();
+    const win = installWindow({ iframe: true });
+
+    client.auth.loginWithProvider("sso", "/dashboard");
+
+    expect(win.open).toHaveBeenCalledOnce();
+    const popupUrl = win.open.mock.calls[0][0] as string;
+    expect(popupUrl).toContain("popup_origin=");
+    expect(popupUrl).not.toContain("version=2");
+    expect(popupUrl).not.toContain("code_challenge");
+  });
+});
+
+describe("redeemSessionHandoffCode", () => {
+  test("returns null synchronously when no handoff params are present", () => {
+    installWindow({ search: "?foo=bar" });
+    const fetchMock = stubFetch();
+    expect(redeemSessionHandoffCode()).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("legacy access_token wins outright when both are present (rollback safety)", () => {
+    installWindow({
+      search: handoffSearch({ extra: "&access_token=legacy-jwt" }),
+    });
+    const fetchMock = stubFetch();
+    expect(redeemSessionHandoffCode()).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("exchanges the code with the verifier and strips the one-time params", async () => {
+    const win = installWindow({
+      search: handoffSearch({ extra: "&is_new_user=true" }),
+    });
+    win.sessionStorage.setItem(PKCE_VERIFIER_STORAGE_KEY, VERIFIER_43);
+    const fetchMock = stubFetch();
+
+    const result = await redeemSessionHandoffCode();
+
+    expect(result).toBe("fresh-jwt");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${APP_ORIGIN}${EXCHANGE_PATH}`);
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({
+      code: "the-code",
+      code_verifier: VERIFIER_43,
+    });
+    // One-time params stripped immediately; is_new_user stays in the URL
+    // exactly as the legacy flow leaves it.
+    const newUrl = win.history.replaceState.mock.calls[0][2];
+    expect(newUrl).toBe("/Dashboard?is_new_user=true");
+    // The verifier is one-shot.
+    expect(win.sessionStorage.getItem(PKCE_VERIFIER_STORAGE_KEY)).toBeNull();
+  });
+
+  test("missing verifier (different-tab login) still attempts and fails closed", async () => {
+    installWindow({ search: handoffSearch() });
+    const fetchMock = stubFetch(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(redeemSessionHandoffCode()).resolves.toBeNull();
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ code: "the-code" });
+    // The named failure mode is called out, not a mystery 401.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("different browser tab")
+    );
+  });
+
+  test("a failed exchange resolves null without throwing", async () => {
+    const win = installWindow({ search: handoffSearch() });
+    win.sessionStorage.setItem(PKCE_VERIFIER_STORAGE_KEY, VERIFIER_43);
+    stubFetch(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(redeemSessionHandoffCode()).resolves.toBeNull();
+    expect(error).toHaveBeenCalled();
+  });
+
+  test("cross-origin session_exchange_path is rejected without a request", async () => {
+    installWindow({
+      search: handoffSearch({ path: "https://evil.example.net/steal" }),
+    });
+    const fetchMock = stubFetch();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(redeemSessionHandoffCode()).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("protocol-relative session_exchange_path is rejected without a request", async () => {
+    installWindow({
+      search: handoffSearch({ path: "//evil.example.net/steal" }),
+    });
+    const fetchMock = stubFetch();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(redeemSessionHandoffCode()).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("network failure resolves null (never rejects)", async () => {
+    const win = installWindow({ search: handoffSearch() });
+    win.sessionStorage.setItem(PKCE_VERIFIER_STORAGE_KEY, VERIFIER_43);
+    stubFetch(async () => {
+      throw new Error("network down");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(redeemSessionHandoffCode()).resolves.toBeNull();
+  });
+
+  test("a success response without an access_token resolves null", async () => {
+    installWindow({ search: handoffSearch() });
+    stubFetch(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    }));
+
+    await expect(redeemSessionHandoffCode()).resolves.toBeNull();
+  });
+});
+
+describe("createClient session-code bootstrap", () => {
+  function allowAnalytics() {
+    nock(SERVER_URL).persist().post(/analytics/).reply(200, {});
+  }
+
+  test("redeems the code and authenticates subsequent requests", async () => {
+    allowAnalytics();
+    const win = installWindow({ search: handoffSearch({ code: "code1" }) });
+    win.sessionStorage.setItem(PKCE_VERIFIER_STORAGE_KEY, VERIFIER_43);
+    stubFetch();
+
+    const client = createClient({
+      serverUrl: SERVER_URL,
+      appId: APP_ID,
+      appBaseUrl: APP_ORIGIN,
+    });
+
+    await vi.waitFor(() =>
+      expect(win.localStorage.getItem("base44_access_token")).toBe("fresh-jwt")
+    );
+
+    const scope = nock(SERVER_URL)
+      .get(`/api/apps/${APP_ID}/entities/User/me`)
+      .matchHeader("Authorization", "Bearer fresh-jwt")
+      .reply(200, { id: "u1" });
+    await client.auth.me();
+    expect(scope.isDone()).toBe(true);
+    client.cleanup();
+  });
+
+  test("backend rollback: legacy ?access_token= is captured as before, no exchange attempted", () => {
+    allowAnalytics();
+    const win = installWindow({ search: "?access_token=legacy-jwt" });
+    const fetchMock = stubFetch();
+
+    const client = createClient({
+      serverUrl: SERVER_URL,
+      appId: APP_ID,
+      appBaseUrl: APP_ORIGIN,
+    });
+
+    expect(win.localStorage.getItem("base44_access_token")).toBe("legacy-jwt");
+    expect(fetchMock).not.toHaveBeenCalled();
+    client.cleanup();
+  });
+
+  test("a failed exchange falls back to a stored token", async () => {
+    allowAnalytics();
+    const win = installWindow({ search: handoffSearch() });
+    win.localStorage.setItem("base44_access_token", "stored-jwt");
+    const fetchMock = stubFetch(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const client = createClient({
+      serverUrl: SERVER_URL,
+      appId: APP_ID,
+      appBaseUrl: APP_ORIGIN,
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const scope = nock(SERVER_URL)
+      .get(`/api/apps/${APP_ID}/entities/User/me`)
+      .matchHeader("Authorization", "Bearer stored-jwt")
+      .reply(200, { id: "u1" });
+    await vi.waitFor(async () => {
+      await client.auth.me();
+    });
+    expect(scope.isDone()).toBe(true);
+    client.cleanup();
+  });
+
+  test("requiresAuth waits for the pending exchange instead of bouncing to login", async () => {
+    allowAnalytics();
+    const win = installWindow({ search: handoffSearch() });
+    win.sessionStorage.setItem(PKCE_VERIFIER_STORAGE_KEY, VERIFIER_43);
+
+    let releaseExchange!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseExchange = resolve;
+    });
+    stubFetch(async () => {
+      await gate;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fresh-jwt" }),
+      };
+    });
+    const probe = nock(SERVER_URL)
+      .get(`/api/apps/${APP_ID}/entities/User/me`)
+      .matchHeader("Authorization", "Bearer fresh-jwt")
+      .reply(200, { id: "u1" });
+
+    const client = createClient({
+      serverUrl: SERVER_URL,
+      appId: APP_ID,
+      appBaseUrl: APP_ORIGIN,
+      requiresAuth: true,
+    });
+
+    // Let the deferred auth probe fire while the exchange is still pending:
+    // it must wait, not redirect to login (that would abandon the exchange
+    // and mint a fresh code every round — a login loop).
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(win.location.href).not.toContain("/login?from_url=");
+
+    releaseExchange();
+    await vi.waitFor(() => expect(probe.isDone()).toBe(true));
+    expect(win.location.href).not.toContain("/login?from_url=");
+    client.cleanup();
+  });
+});


### PR DESCRIPTION
Implements **§5.2 (SDK)** of base44-dev/apper#17216 — the client side of the PKCE-gated SSO session-code handoff. Backend (§5.1) merged in base44-dev/apper#17592.

## The contract: negotiation, never deprecation

The SDK **offers** the handoff at SSO kickoff (`version=2` + S256 `code_challenge`) and the backend **decides** per request. Whatever the server answers with, the SDK digests:

- `session_code` + `session_exchange_path` in the redirect → same-origin `POST {code, code_verifier}` → token from the **response body**.
- Legacy `?access_token=` — because the flag is off, the app isn't in the cohort, **or the backend was rolled back** — → the pre-existing capture path runs byte-identically. If both ever coexist in a URL, legacy wins outright.

A backend rollback is therefore a non-event for apps on this SDK.

## Kickoff (`loginWithProvider("sso")`, full-page only)

Generate a 43-char base64url PKCE verifier, persist it in per-tab `sessionStorage` **with read-back verification**, append `&version=2&code_challenge=<S256>&code_challenge_method=S256`. **Any** local failure — no WebCrypto, no fetch, storage throws or silently drops the write — falls back to the exact legacy kickoff URL. We never opt in to an exchange this browser can't complete: the server 400s a challenge-less `version=2` login, and an opted-in login with a lost verifier could never redeem its code.

**Popups/iframes are byte-identical to before**: they deliver via postMessage and never redeem a code (the backend skips the mint when `popup_origin` is present). Their token-in-URL fix is deliberately a separate follow-up PR so it stays independently revertable (per the issue's rollout note — it has no server-side kill-switch).

## Redemption (`createClient` bootstrap)

- One-time params stripped from the URL immediately; `is_new_user` stays, exactly as legacy leaves it.
- **Same-origin enforcement on `session_exchange_path`** — it arrives via the URL, so it's tainted; POSTing the code + verifier to an attacker-chosen origin would hand over both halves of the PKCE proof. Absolute and protocol-relative foreign origins are rejected without a request.
- Verifier is one-shot (removed from storage regardless of outcome).
- A failed exchange resolves `null` — never throws, never redirects — and falls back to any stored token. Each fresh login mints a fresh code, so failure self-heals rather than looping.
- The `requiresAuth` probe **awaits the pending exchange**. Probing early would 401 → redirect to login → abandon the in-flight exchange → fresh code every round: the BUG-787 login-loop shape, recreated client-side. Covered by a dedicated test.
- Named expected failure (from the issue): a login that completes in a different tab loses the per-tab verifier; the exchange is still attempted (fails closed server-side, code not burned) and the SDK logs an explicit "finished in a different browser tab" warning instead of a mystery 401.

## One decision worth a look

On exchange failure the SDK falls back to a localStorage token if one exists (mirroring `getAccessToken`'s storage fallback) rather than leaving auth state empty. Happy to fail fully clean instead if preferred.

## Tests

New `tests/unit/session-handoff.test.ts` (23 tests): challenge/verifier RFC 7636 correctness, every fail-open kickoff branch, popup/non-SSO kickoff unchanged, exchange happy path + param stripping, missing-verifier named failure, cross-origin and protocol-relative exchange-path rejection, network-failure resilience, client bootstrap precedence, **backend-rollback parity** (legacy `access_token` captured with zero exchange attempts), and the `requiresAuth`-waits-for-exchange loop guard.

`npm test`: **228 passed** (22 files), type check + lint + build clean.

Rollout note (§5.3): inert until the backend flag `sso-pkce-custom-domains` targets an app; un-upgraded bundles keep working on legacy regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)