### PR TITLE
fix(auth): share the in-flight me() request

### DIFF
--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -229,7 +229,12 @@ async function startAnalyticsProcessor(
 }
 
 function startHeartBeatProcessor(track: (params: TrackEventParams) => void) {
+  // Browser-only, like the other automatic events here (initialization, session
+  // duration, visibility). Outside a browser this timer fired a `me()` every
+  // interval for the lifetime of a long-lived server-side client, and kept the
+  // Node event loop alive. Explicit `analytics.track()` calls still work.
   if (
+    typeof window === "undefined" ||
     analyticsSharedState.isHeartBeatProcessing ||
     (analyticsSharedState.config.heartBeatInterval ?? 0) < 10
   ) {
@@ -307,6 +312,22 @@ function transformEventDataToApiRequestData(sessionContext: SessionContext) {
 }
 
 let sessionContextPromise: Promise<SessionContext> | null = null;
+
+/**
+ * Clears the memoized analytics session context.
+ *
+ * The context holds the `user_id` resolved by `auth.me()` and is reused for the
+ * lifetime of the session, so it has to be dropped whenever the identity
+ * changes. Without this, a visitor who loads a page anonymously and then logs in
+ * keeps reporting `user_id: null` on every subsequent event.
+ *
+ * @internal
+ */
+export function resetAnalyticsSessionContext() {
+  analyticsSharedState.sessionContext = null;
+  sessionContextPromise = null;
+}
+
 async function getSessionContext(
   userAuthModule: AuthModule
 ): Promise<SessionContext> {

--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -345,7 +345,18 @@ async function getSessionContext(
           session_id: sessionId,
         }));
     }
-    analyticsSharedState.sessionContext = await sessionContextPromise;
+    const pending = sessionContextPromise;
+    const context = await pending;
+    // Publish only if this lookup is still the current one. A reset that lands
+    // while the request is in flight nulls `sessionContextPromise`, and an
+    // unconditional write here would put the pre-reset identity back and pin it
+    // for the rest of the session. The awaited value is still returned: these
+    // events were queued before the identity changed, so that is who they
+    // belong to.
+    if (sessionContextPromise === pending) {
+      analyticsSharedState.sessionContext = context;
+    }
+    return context;
   }
   return analyticsSharedState.sessionContext;
 }

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -111,11 +111,15 @@ export function createAuthModule(
   return {
     // Get current user information
     async me() {
-      const request =
+      const request: Promise<User> =
         pendingMe ??
-        axios
-          .get<any, User>(`/apps/${appId}/entities/User/me`)
-          .finally(clearPendingMe);
+        axios.get<any, User>(`/apps/${appId}/entities/User/me`).finally(() => {
+          // Only retire this request if it is still the shared one. An identity
+          // change mid-flight clears `pendingMe` and the next caller starts a
+          // fresh request; an unconditional clear here would retire that newer
+          // request instead, so a third caller would issue a duplicate.
+          if (pendingMe === request) pendingMe = null;
+        });
       pendingMe = request;
       return request;
     },

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -2,10 +2,12 @@ import { AxiosInstance } from "axios";
 import {
   AuthModule,
   AuthModuleOptions,
+  User,
   VerifyOtpParams,
   ChangePasswordParams,
   ResetPasswordParams,
 } from "./auth.types";
+import { resetAnalyticsSessionContext } from "./analytics.js";
 
 function isInsideIframe(): boolean {
   if (typeof window === "undefined") return false;
@@ -91,10 +93,31 @@ export function createAuthModule(
   appId: string,
   options: AuthModuleOptions
 ): AuthModule {
+  // In-flight `me()` request, shared by concurrent callers. The analytics
+  // module resolves its session context through `me()` at client construction,
+  // at the same moment most apps issue their own `me()`. Browsers serialize the
+  // two identical GETs, so the second pays the first's full latency on every
+  // cold load.
+  //
+  // This shares the pending promise only — it is cleared as soon as the request
+  // settles, so no resolved user is ever retained. Caching the user across
+  // requests would leave the app rendering a stale identity after logout or a
+  // session swap.
+  let pendingMe: Promise<User> | null = null;
+  const clearPendingMe = () => {
+    pendingMe = null;
+  };
+
   return {
     // Get current user information
     async me() {
-      return axios.get(`/apps/${appId}/entities/User/me`);
+      const request =
+        pendingMe ??
+        axios
+          .get<any, User>(`/apps/${appId}/entities/User/me`)
+          .finally(clearPendingMe);
+      pendingMe = request;
+      return request;
     },
 
     // Update current user data
@@ -158,6 +181,11 @@ export function createAuthModule(
       // Remove token from axios headers (always do this)
       delete axios.defaults.headers.common["Authorization"];
 
+      // Drop identity resolved under the previous session: a `me()` already in
+      // flight would otherwise resolve into callers that run after the logout.
+      clearPendingMe();
+      resetAnalyticsSessionContext();
+
       // Only do the rest if in a browser environment
       if (typeof window !== "undefined") {
         // Remove token from localStorage
@@ -183,6 +211,11 @@ export function createAuthModule(
     // Set authentication token
     setToken(token: string, saveToStorage = true) {
       if (!token) return;
+
+      // Same reasoning as in `logout`: the identity changes here, so anything
+      // resolved for the previous one must not be handed to later callers.
+      clearPendingMe();
+      resetAnalyticsSessionContext();
 
       // handle token change for axios clients
       axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -93,6 +93,30 @@ describe("Analytics Module", () => {
     expect(sharedState?.sessionContext).toBeNull();
   });
 
+  test("should not restore the pre-reset identity when a lookup settles late", async () => {
+    resetAnalyticsSessionContext();
+
+    let resolveMe: (user: User) => void;
+    vi.spyOn(base44.auth, "me").mockReturnValue(
+      new Promise<User>((resolve) => {
+        resolveMe = resolve;
+      })
+    );
+
+    // Flushing this event resolves the session context, which suspends on me().
+    base44.analytics.track({ eventName: "anonymous-event" });
+    await vi.waitFor(() => expect(base44.auth.me).toHaveBeenCalled());
+
+    // The identity changes while that lookup is still in flight.
+    resetAnalyticsSessionContext();
+    resolveMe!({ id: "anonymous-user" } as User);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The anonymous identity must not be written back: doing so pins user_id
+    // for the rest of the session, which is the bug the reset exists to prevent.
+    expect(sharedState?.sessionContext).toBeNull();
+  });
+
   test("should not start the heartbeat outside a browser", () => {
     const heartBeatState = sharedState as unknown as {
       isHeartBeatProcessing: boolean;

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -6,6 +6,7 @@ import {
   TrackEventData,
 } from "../../src/index.ts";
 import { getSharedInstance } from "../../src/utils/sharedInstance.ts";
+import { resetAnalyticsSessionContext } from "../../src/modules/analytics.ts";
 import { User } from "../../src/modules/auth.types.ts";
 import { AxiosInstance } from "axios";
 
@@ -80,6 +81,25 @@ describe("Analytics Module", () => {
     expect(base44.analytics.track).toHaveBeenCalledWith({
       eventName: "test-event",
     });
+  });
+
+  test("should clear the memoized session context on reset", () => {
+    expect(sharedState?.sessionContext).toEqual({ user_id: "test-user-id" });
+
+    resetAnalyticsSessionContext();
+
+    // Called on every identity change. Without it, a visitor who loads
+    // anonymously and then logs in keeps reporting the pre-login identity.
+    expect(sharedState?.sessionContext).toBeNull();
+  });
+
+  test("should not start the heartbeat outside a browser", () => {
+    const heartBeatState = sharedState as unknown as {
+      isHeartBeatProcessing: boolean;
+    };
+
+    expect(typeof window).toBe("undefined");
+    expect(heartBeatState.isHeartBeatProcessing).toBeFalsy();
   });
 
   test("should track multiple events", async () => {

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -150,6 +150,33 @@ describe('Auth Module', () => {
       expect(scope.isDone()).toBe(true);
     });
 
+    test('a superseded request does not retire the current one', async () => {
+      scope
+        .get(`/api/apps/${appId}/entities/User/me`)
+        .delay(50)
+        .reply(200, { id: 'anonymous' });
+      // One interceptor for the post-login identity: if the settling anonymous
+      // request retires it, the third caller issues a second GET and this test
+      // hits disableNetConnect.
+      scope
+        .get(`/api/apps/${appId}/entities/User/me`)
+        .delay(50)
+        .reply(200, { id: 'logged-in' });
+
+      const beforeLogin = base44.auth.me();
+      base44.auth.setToken('new-access-token', false);
+      const afterLogin = base44.auth.me();
+
+      // Let the anonymous request settle while the post-login one is still in
+      // flight, then join it.
+      await expect(beforeLogin).resolves.toEqual({ id: 'anonymous' });
+      const joined = base44.auth.me();
+
+      expect(await afterLogin).toEqual({ id: 'logged-in' });
+      expect(await joined).toEqual({ id: 'logged-in' });
+      expect(scope.isDone()).toBe(true);
+    });
+
     test('setToken() clears the analytics session context', () => {
       const analyticsState = getSharedInstance('analytics', () => ({}));
       analyticsState.sessionContext = { user_id: 'anonymous-user', session_id: 's1' };

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import nock from 'nock';
 import { createClient } from '../../src/index.ts';
+import { getSharedInstance } from '../../src/utils/sharedInstance.ts';
 
 describe('Auth Module', () => {
   let base44;
@@ -90,8 +91,75 @@ describe('Auth Module', () => {
       // Verify all mocks were called
       expect(scope.isDone()).toBe(true);
     });
+
+    test('shares one in-flight request between concurrent callers', async () => {
+      const mockUser = { id: 'user-123', email: 'test@example.com' };
+
+      // A single interceptor: a second GET would hit disableNetConnect and throw.
+      scope.get(`/api/apps/${appId}/entities/User/me`).reply(200, mockUser);
+
+      const [first, second] = await Promise.all([
+        base44.auth.me(),
+        base44.auth.me(),
+      ]);
+
+      expect(first).toEqual(mockUser);
+      expect(second).toEqual(mockUser);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    test('does not reuse a resolved user across separate calls', async () => {
+      scope.get(`/api/apps/${appId}/entities/User/me`).reply(200, { id: 'user-1' });
+      scope.get(`/api/apps/${appId}/entities/User/me`).reply(200, { id: 'user-2' });
+
+      const first = await base44.auth.me();
+      const second = await base44.auth.me();
+
+      // Sharing is limited to the in-flight window; identity is never cached.
+      expect(first.id).toBe('user-1');
+      expect(second.id).toBe('user-2');
+      expect(scope.isDone()).toBe(true);
+    });
+
+    test('does not retain a rejected request', async () => {
+      const mockUser = { id: 'user-123' };
+      scope.get(`/api/apps/${appId}/entities/User/me`).reply(401, { detail: 'Unauthorized' });
+      scope.get(`/api/apps/${appId}/entities/User/me`).reply(200, mockUser);
+
+      await expect(base44.auth.me()).rejects.toThrow();
+      await expect(base44.auth.me()).resolves.toEqual(mockUser);
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    test('setToken() drops an in-flight request from the previous identity', async () => {
+      scope
+        .get(`/api/apps/${appId}/entities/User/me`)
+        .delay(50)
+        .reply(200, { id: 'anonymous' });
+      scope.get(`/api/apps/${appId}/entities/User/me`).reply(200, { id: 'logged-in' });
+
+      const beforeLogin = base44.auth.me();
+      base44.auth.setToken('new-access-token', false);
+      const afterLogin = await base44.auth.me();
+
+      // The call made after the identity change must not resolve into the
+      // request that was already in flight for the anonymous one.
+      expect(afterLogin.id).toBe('logged-in');
+      await expect(beforeLogin).resolves.toEqual({ id: 'anonymous' });
+      expect(scope.isDone()).toBe(true);
+    });
+
+    test('setToken() clears the analytics session context', () => {
+      const analyticsState = getSharedInstance('analytics', () => ({}));
+      analyticsState.sessionContext = { user_id: 'anonymous-user', session_id: 's1' };
+
+      base44.auth.setToken('new-access-token', false);
+
+      expect(analyticsState.sessionContext).toBeNull();
+    });
   });
-  
+
   describe('updateMe()', () => {
     test('should update current user data', async () => {
       const updateData = {


### PR DESCRIPTION
## Problem

`BUG-837`: an app is ~190ms slower on every cold load because the SDK issues a second `GET /entities/User/me` at client construction while the app is already issuing its own. Chrome serializes the two identical GETs, so the second pays the first's full latency.

The source is the analytics module: `createAnalyticsModule` runs at client construction, `trackInitializationEvent` queues an event, `startAnalyticsProcessor` sends the first batch *before* the `throttleTime` sleep, and `flush()` awaits `getSessionContext()` → `auth.me()`.

## Fix

Share the in-flight request in `auth.me()`. Both the app and analytics call this same method, so collapsing it there is what removes the duplicate — deduping inside the analytics module would not help, and `getSessionContext` already shares its own promise.

The pending promise is cleared as soon as the request settles, so **no resolved user is ever retained**. Caching identity across requests would leave an app rendering a logged-in view after logout or a session swap. `setToken` and `logout` also drop the pending request: a `me()` already in flight must not resolve into callers that run after the identity changed.

This also collapses apps that call `me()` twice on their own.

## Two related fixes in the analytics module

- **Stale `user_id`.** The session context memoized the resolved `user_id` for the lifetime of the session and nothing ever reset it — not `logout`, not `setToken`. A visitor who loaded a page anonymously and then logged in kept reporting `user_id: null` on every subsequent event. It is now cleared on any identity change. This is a data-quality bug, not a latency one.
- **Heartbeat outside the browser.** `startHeartBeatProcessor` was not window-guarded, unlike the other automatic events here (initialization, session duration, visibility). On a long-lived server-side client it fired a `me()` every 60s and its interval kept the Node event loop alive. Explicit `analytics.track()` calls from backend functions are unaffected.

## Scope — what this does not fix

Prod data (24h) shows ~88% of the 5.34M daily `User/me` calls come from the server-side SDK in backend functions, not browsers. This PR removes one request per cold browser load; it does not touch that server-side share, and it does not touch the ~33ms of per-request app-metadata reload that dominates the endpoint's 40ms p50. That work is separate, in `apper`.

**The Datadog p50 will not move on merge day.** The SDK is pinned at `^0.8.35` in the app templates, so apps pick this up on their next install or rebuild; the deployed fleet trails.

## Testing

`npm run test:unit` — 199 pass (7 new). Lint, type-tests, and build clean.

The concurrency test uses a single nock interceptor with `disableNetConnect`, so a second GET fails the test; verified it fails against the unfixed `me()`.

Not covered: no browser-level test that the two GETs actually stop serializing — the fix is asserted at the request-count level.

## Noticed, not fixed

`flush()`'s beacon branch looks inverted: `beaconRequest` returns `true` when the beacon *cannot* be used, so `if (!options.isBeacon || !beaconRequest(events))` skips the axios fallback exactly when the beacon failed, and double-sends when it succeeded. Left alone as unrelated to this fix — worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)