### PR TITLE
ci: pin actions to commit SHAs in check-wix-proxy.yml

### DIFF
--- a/.github/workflows/check-wix-proxy.yml
+++ b/.github/workflows/check-wix-proxy.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What

Pins `actions/checkout` and `actions/setup-python` to commit SHAs in `check-wix-proxy.yml`.

## Why

The repo's Actions policy has `sha_pinning_required: true`, so this workflow has hit `startup_failure` on every run since it first triggered (all 4 runs, starting 2026-08-16 09:48 UTC). Since it's meant to be a required status check, every PR and push to `main` currently fails it at startup.

#249 pinned all eight other workflows but missed this file.

## Details

- `actions/checkout@v4` → `11d5960a` — same SHA already used by every other workflow in the repo
- `actions/setup-python@v6` → `ece7cb06` — resolved from the `v6` tag on actions/setup-python

Verified no unpinned `uses:` references remain in `.github/workflows/` or `.github/actions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)