### PR TITLE
fix(analytics): skip the identity lookup when no token is set

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -150,6 +150,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
     {
       appBaseUrl: normalizedAppBaseUrl,
       serverUrl,
+      token,
     }
   );
 

--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -9,7 +9,7 @@ import {
   SessionContext,
 } from "./analytics.types";
 import { getSharedInstance } from "../utils/sharedInstance.js";
-import type { AuthModule } from "./auth.types";
+import type { InternalAuthModule } from "./auth.types";
 import { generateUuid, isReactNative } from "../utils/common.js";
 
 export const USER_HEARTBEAT_EVENT_NAME = "__user_heartbeat_event__";
@@ -58,7 +58,7 @@ export interface AnalyticsModuleArgs {
   axiosClient: AxiosInstance;
   serverUrl: string;
   appId: string;
-  userAuthModule: AuthModule;
+  userAuthModule: InternalAuthModule;
 }
 
 export const createAnalyticsModule = ({
@@ -329,7 +329,7 @@ export function resetAnalyticsSessionContext() {
 }
 
 async function getSessionContext(
-  userAuthModule: AuthModule
+  userAuthModule: InternalAuthModule
 ): Promise<SessionContext> {
   if (!analyticsSharedState.sessionContext) {
     // With no token there is no identity to resolve: `me()` can only answer 401,

--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -332,6 +332,14 @@ async function getSessionContext(
   userAuthModule: AuthModule
 ): Promise<SessionContext> {
   if (!analyticsSharedState.sessionContext) {
+    // With no token there is no identity to resolve: `me()` can only answer 401,
+    // which the browser logs to the console before any handler here sees it. On
+    // a public page that request is the sole reason an error appears, so skip
+    // it. This is not memoized — a visitor who logs in later must still resolve.
+    if (!userAuthModule.hasToken()) {
+      return { user_id: null, session_id: getAnalyticsSessionId() };
+    }
+
     if (!sessionContextPromise) {
       const sessionId = getAnalyticsSessionId();
       sessionContextPromise = userAuthModule

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -108,7 +108,16 @@ export function createAuthModule(
     pendingMe = null;
   };
 
+  // Tracked here rather than read off `axios.defaults` so the answer stays tied
+  // to the identity transitions below (`setToken`, `logout`) instead of to the
+  // header a caller may have set on the instance directly.
+  let hasAccessToken = Boolean(options.token);
+
   return {
+    hasToken() {
+      return hasAccessToken;
+    },
+
     // Get current user information
     async me() {
       const request: Promise<User> =
@@ -189,6 +198,7 @@ export function createAuthModule(
       // flight would otherwise resolve into callers that run after the logout.
       clearPendingMe();
       resetAnalyticsSessionContext();
+      hasAccessToken = false;
 
       // Only do the rest if in a browser environment
       if (typeof window !== "undefined") {
@@ -220,6 +230,7 @@ export function createAuthModule(
       // resolved for the previous one must not be handed to later callers.
       clearPendingMe();
       resetAnalyticsSessionContext();
+      hasAccessToken = true;
 
       // handle token change for axios clients
       axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from "axios";
 import {
-  AuthModule,
   AuthModuleOptions,
+  InternalAuthModule,
   User,
   VerifyOtpParams,
   ChangePasswordParams,
@@ -92,7 +92,7 @@ export function createAuthModule(
   functionsAxiosClient: AxiosInstance,
   appId: string,
   options: AuthModuleOptions
-): AuthModule {
+): InternalAuthModule {
   // In-flight `me()` request, shared by concurrent callers. The analytics
   // module resolves its session context through `me()` at client construction,
   // at the same moment most apps issue their own `me()`. Browsers serialize the

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -100,6 +100,12 @@ export interface AuthModuleOptions {
   serverUrl: string;
   /** Base URL for the app (used for login redirects). */
   appBaseUrl: string;
+  /**
+   * Access token the client was constructed with, if any. Seeds the module's
+   * view of whether a session exists before {@link AuthModule.setToken} runs,
+   * which is how the server-side SDK reports a token it never sets explicitly.
+   */
+  token?: string;
 }
 
 /**
@@ -120,6 +126,17 @@ export interface AuthModuleOptions {
  * The auth module is only available in user authentication mode (`base44.auth`).
  */
 export interface AuthModule {
+  /**
+   * Whether an access token is currently set on the client.
+   *
+   * Reports only the presence of a token, never its validity — an expired or
+   * revoked token still reads as `true`. Callers use this to skip requests that
+   * could not succeed without a session, not to decide that one is valid.
+   *
+   * @internal
+   */
+  hasToken(): boolean;
+
   /**
    * Gets the current authenticated user's information.
    *

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -127,17 +127,6 @@ export interface AuthModuleOptions {
  */
 export interface AuthModule {
   /**
-   * Whether an access token is currently set on the client.
-   *
-   * Reports only the presence of a token, never its validity — an expired or
-   * revoked token still reads as `true`. Callers use this to skip requests that
-   * could not succeed without a session, not to decide that one is valid.
-   *
-   * @internal
-   */
-  hasToken(): boolean;
-
-  /**
    * Gets the current authenticated user's information.
    *
    * @returns Promise resolving to the user's profile data.
@@ -560,4 +549,22 @@ export interface AuthModule {
    * ```
    */
   changePassword(params: ChangePasswordParams): Promise<any>;
+}
+
+/**
+ * The auth module as constructed internally, before it is narrowed to
+ * {@link AuthModule} on the public client. Not exported from the package
+ * index — SDK consumers see only {@link AuthModule}.
+ *
+ * @internal
+ */
+export interface InternalAuthModule extends AuthModule {
+  /**
+   * Whether an access token is currently set on the client.
+   *
+   * Reports only the presence of a token, never its validity — an expired or
+   * revoked token still reads as `true`. Callers use this to skip requests that
+   * could not succeed without a session, not to decide that one is valid.
+   */
+  hasToken(): boolean;
 }

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/index.ts";
 import { getSharedInstance } from "../../src/utils/sharedInstance.ts";
 import { resetAnalyticsSessionContext } from "../../src/modules/analytics.ts";
-import { User } from "../../src/modules/auth.types.ts";
+import { InternalAuthModule, User } from "../../src/modules/auth.types.ts";
 import { AxiosInstance } from "axios";
 
 describe("Analytics Module", () => {
@@ -169,14 +169,17 @@ describe("Analytics Module", () => {
 
   test("should report token presence across identity changes", () => {
     const client = createClient({ serverUrl, appId });
+    // `hasToken` lives on the internal auth surface only; the public client
+    // narrows to AuthModule, so reach past the narrowing deliberately here.
+    const auth = client.auth as InternalAuthModule;
 
-    expect(client.auth.hasToken()).toBe(false);
+    expect(auth.hasToken()).toBe(false);
 
-    client.auth.setToken("some-token", false);
-    expect(client.auth.hasToken()).toBe(true);
+    auth.setToken("some-token", false);
+    expect(auth.hasToken()).toBe(true);
 
-    client.auth.logout();
-    expect(client.auth.hasToken()).toBe(false);
+    auth.logout();
+    expect(auth.hasToken()).toBe(false);
 
     client.cleanup();
   });

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -26,6 +26,9 @@ describe("Analytics Module", () => {
       createAxiosClient: vi.fn().mockImplementation(
         () =>
           ({
+            // `setToken` and `logout` write through to these, so the mock needs
+            // them present per instance.
+            defaults: { headers: { common: {} as Record<string, string> } },
             request: vi.fn().mockResolvedValue({
               status: 200,
               data: {
@@ -54,9 +57,12 @@ describe("Analytics Module", () => {
       heartBeatInterval: undefined,
     };
 
+    // Token-bearing by default: most tests here exercise the flush path that
+    // resolves an identity, and that lookup is skipped without a session.
     base44 = createClient({
       serverUrl,
       appId,
+      token: "test-access-token",
     });
   });
 
@@ -124,6 +130,55 @@ describe("Analytics Module", () => {
 
     expect(typeof window).toBe("undefined");
     expect(heartBeatState.isHeartBeatProcessing).toBeFalsy();
+  });
+
+  test("should not resolve an identity when no token is set", async () => {
+    resetAnalyticsSessionContext();
+
+    const anonymous = createClient({ serverUrl, appId });
+    const me = vi.spyOn(anonymous.auth, "me");
+
+    anonymous.analytics.track({ eventName: "public-page-event" });
+    await vi.waitFor(() => expect(sharedState?.requestsQueue.length).toBe(0));
+
+    // The whole point: on a public page `me()` can only answer 401, and the
+    // browser logs that to the console before any handler here sees it. The
+    // event still flushes -- anonymous events already reported user_id: null.
+    expect(me).not.toHaveBeenCalled();
+
+    anonymous.cleanup();
+  });
+
+  test("should resolve an identity once a token is set", async () => {
+    resetAnalyticsSessionContext();
+
+    const anonymous = createClient({ serverUrl, appId });
+    const me = vi
+      .spyOn(anonymous.auth, "me")
+      .mockResolvedValue({ id: "user-1" } as User);
+
+    // A visitor who logs in mid-session must start reporting their identity, so
+    // the skip above must not be memoized.
+    anonymous.auth.setToken("token-acquired-after-login", false);
+    anonymous.analytics.track({ eventName: "post-login-event" });
+
+    await vi.waitFor(() => expect(me).toHaveBeenCalled());
+
+    anonymous.cleanup();
+  });
+
+  test("should report token presence across identity changes", () => {
+    const client = createClient({ serverUrl, appId });
+
+    expect(client.auth.hasToken()).toBe(false);
+
+    client.auth.setToken("some-token", false);
+    expect(client.auth.hasToken()).toBe(true);
+
+    client.auth.logout();
+    expect(client.auth.hasToken()).toBe(false);
+
+    client.cleanup();
   });
 
   test("should track multiple events", async () => {


### PR DESCRIPTION
## Problem

On a **public page**, the SDK issues a `GET /entities/User/me` that can only ever answer 401, and the browser writes `Failed to load resource: the server responded with a status of 401 (Unauthorized)` to the console. Users read that as a broken app. ([reported here](https://base44workspace.slack.com/archives/C09AR6ZR9L3/p1786965509128379) — app_id `69f14bfdfba5c17e67d8e81b`, where the user won't ship while there are console errors.)

The request comes from analytics, not from the app. `createAnalyticsModule` runs at client construction → `trackInitializationEvent` queues an event → the processor flushes the first batch immediately → `flush` awaits `getSessionContext` → `auth.me()`, unconditionally, whether or not a session exists.

**Catching it harder does not help, and that is the main thing to know about this PR.** The rejection is already handled at three levels:

| Location | |
|---|---|
| `analytics.ts:343` | `.catch(() => ({ user_id: null, session_id }))` |
| `analytics.ts:121` | `try { ... } catch { /* do nothing */ }` in `flush` |
| `axios-client.ts:261` | rejects with `Base44Error`, consumed by the above |

Nothing escapes as an unhandled rejection. The console line is emitted by the browser's network stack *before* any JS handler runs, so no `try`/`catch` can suppress it. The only way to remove it is to not send the request.

## Fix

Skip the identity lookup when no access token is set:

```ts
// analytics.ts, getSessionContext
if (!userAuthModule.hasToken()) {
  return { user_id: null, session_id: getAnalyticsSessionId() };
}
```

Anonymous events already reported `user_id: null` through the existing `.catch`, so **no analytics data changes** — the request is dropped only in the case where its sole possible outcome was a 401.

Token presence is tracked in the auth module rather than read off `axios.defaults`, so it follows the identity transitions that already live there (`setToken`, `logout`) instead of a header a caller may have set on the instance directly. It is seeded from the constructor token, which is how the server-side SDK carries a session it never sets explicitly — without that seeding this would have silently stopped resolving `user_id` in backend functions.

The skip is deliberately **not** memoized: a visitor who loads a page anonymously and then logs in has to start resolving an identity again.

## This does not revert or weaken #245

#245 removed a *duplicate* `User/me` on authenticated cold loads by sharing the in-flight promise in `auth.me()`. That optimization is untouched and still exercised: when a token is present, analytics resolves through `auth.me()` exactly as before and shares the app's in-flight request.

| Scenario | Before #245 | After #245 (main) | This PR |
|---|---|---|---|
| Public page, no token | 1 request → 401 in console | 1 request → 401 in console | **0 requests, no console error** |
| Authed cold load, app calls `me()` | 2 requests (serialized) | 1 shared request | 1 shared request |
| Authed, app never calls `me()` | 1 request | 1 request | 1 request |
| Backend function (server-side SDK) | 1 request | 1 request | 1 request |

The two PRs address different halves of the same endpoint: #245 cut the redundant request for logged-in users, this one cuts the impossible request for anonymous ones.

## Scope — what this does not fix

A **stale or expired** token in localStorage still produces one 401. A token is present, so the request goes out; its validity isn't knowable client-side. Removing that one requires `User/me` to answer `200` with a null user instead of `401` — a backend change, not this repo. If the goal is "zero 401s on `/User/me` under any condition", that is the change to make, and this PR is not a substitute for it.

Also unchanged: `[Base44 SDK Error] 401: ...` from `safeErrorLog` (`axios-client.ts:255`) is already gated behind `process.env.NODE_ENV !== "production"` and is stripped from prod builds. Worth confirming published apps are served as production builds, otherwise that line appears alongside the browser's.

As with #245, the SDK is pinned at `^0.8.x` in the app templates, so apps pick this up on their next install or rebuild — the deployed fleet trails.

## Testing

`npm run lint`, `npm run build`, `npm run test:types` clean. `npm run test:unit` — **204 pass** (3 new).

New tests:
- analytics does not call `me()` when no token is set
- resolution resumes after `setToken` (guards the not-memoized behavior)
- `hasToken()` tracks `setToken` → `logout`

Verified the first genuinely fails with the gate disabled, rather than passing vacuously.

Two existing tests changed, and the reason is worth a look rather than a rubber stamp: `should not restore the pre-reset identity when a lookup settles late` and `should track multiple events` both exercise the identity-resolution path, so their client is now token-bearing. With the token restored, their batching and throttle assertions pass **unchanged** — which is what rules out a regression in the processor loop, since removing an `await` from `flush` shifts microtask ordering. The file's axios mock also gains the `defaults` object that `setToken`/`logout` have always written through.

Not covered: no browser-level test asserting the console stays clean; the fix is asserted at the request level.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtKFfzaVR6nWAi8tNvJqfw)_