### PR TITLE
ci: Use cooldown-compatible Claude action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c # v1.0.193
+        uses: anthropics/claude-code-action@9db594c7a0e82298c121c18b7f08aa1579ce7341 # v1.0.185
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c # v1.0.193
+        uses: anthropics/claude-code-action@9db594c7a0e82298c121c18b7f08aa1579ce7341 # v1.0.185
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
### What?

Pins both Claude workflows to v1.0.185, the newest v1 release currently compatible with our 14-day npm cooldown.

### Why?

PR #257 moved us to v1.0.193 for its write-access check, but that release locks Claude Agent SDK 0.3.233, published on August 14, so the Wix npm gateway rejects it. v1.0.185 has the same write-access check and locks SDK 0.3.222, published on August 4.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=9c1b6cf6-d979-4368-bd0e-6cb6aca8cc1c) · `dev3://task/9c1b6cf6-d979-4368-bd0e-6cb6aca8cc1c`