### PR TITLE
docs(auth): correct updateMe role guidance

### DIFF
--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -147,8 +147,7 @@ export interface AuthModule {
    * You can update any [custom fields](/developers/backend/resources/entities/user-schema#custom-fields)
    * defined in your User entity schema.
    *
-   * Updating `role` requires editor access on the app. An app user without it
-   * gets a 403 response, and none of the other fields in the request are applied.
+   * Updating `role` requires editor access on the app.
    *
    * <Note>
    * These fields can't be changed with this method:

--- a/src/modules/auth.types.ts
+++ b/src/modules/auth.types.ts
@@ -144,12 +144,16 @@ export interface AuthModule {
   /**
    * Updates the current authenticated user's information.
    *
-   * You can update `role` and any [custom fields](/developers/backend/resources/entities/user-schema#custom-fields) defined in your
-   * User entity schema.
-   * The `role` value must be either `'user'` or `'admin'`.
+   * You can update any [custom fields](/developers/backend/resources/entities/user-schema#custom-fields)
+   * defined in your User entity schema.
+   *
+   * Updating `role` requires editor access on the app. An app user without it
+   * gets a 403 response, and none of the other fields in the request are applied.
+   *
    * <Note>
-   * The following fields are read-only and can't be changed with this method:
-   * `id`, `email`, `full_name`, `created_date`, `updated_date`, and `created_by`.
+   * These fields can't be changed with this method:
+   * `id`, `email`, `full_name`, `created_date`, `updated_date`, `created_by`,
+   * and `collaborator_role`.
    * </Note>
    *
    * @param data - Object containing the fields to update.
@@ -157,9 +161,8 @@ export interface AuthModule {
    *
    * @example
    * ```typescript
-   * // Update role and custom fields defined in your User entity
+   * // Update custom fields defined in your User entity
    * await base44.auth.updateMe({
-   *   role: 'admin',
    *   bio: 'Software developer',
    *   preferences: { theme: 'dark' }
    * });


### PR DESCRIPTION
## What

The `updateMe` JSDoc tells readers they can set the built-in `role` field, in three separate places: the prose, the example's title, and the example body. Anyone who copies the snippet hits a 403.

## Why

Reported by a user on 12 Aug 2026, who tested against the live API before writing in:

> The updateMe documentation states users can update the built-in `role` field, but a real request returns 403 "You do not have permission to update user roles." Please correct the documentation and explicitly list protected built-in fields.

They are right. `updateMe` sends `PUT /apps/{appId}/entities/User/me`, which lands in `UserCRUD.update` in apper:

```python
new_user_role = payload.pop("role", None)
if new_user_role is not None and new_user_role != entity.app_role:
    await update_user_role(app, entity, new_user_role)
```

`role` never travels with the rest of the fields. It is pulled out and sent through `update_user_role`, which requires `collaborator_role="editor"` or platform blanket access. An ordinary signed-in app user has neither. Because the check runs before the payload merge, the 403 also means none of the other fields land.

## Changes

- Drop the claim that `role` is updatable, and drop `role` from the example.
- Say that updating `role` requires editor access, rather than moving `role` into the read-only list. Owners and editor collaborators genuinely can change it, so calling it read-only would be a second inaccuracy in the other direction.
- Add `collaborator_role` to the protected-field list. The same function discards it with `payload.pop("collaborator_role", None)` and no error, which is worse for the caller than a 403.

## Note on history

This wording came from `fix-updateme-role-docs-17-may-hadas`, including a commit titled "Clarify updateMe: role is updatable, fix read-only field list." The most likely explanation is that it was tested as an app owner, where setting `role` does succeed. That path still works and is now documented as such.

## Docs

`developers/references/sdk/docs/interfaces/auth` is generated from this JSDoc, so the fix has to land here or it gets wiped on the next regeneration. Regenerated output is in a paired mintlify-docs PR. Merge this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)