### PR TITLE
fix: pin axios exactly so consumers cannot resolve an uncached release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.44",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.18.1",
+        "axios": "1.18.1",
         "partysocket": "^0.0.23",
         "socket.io-client": "^4.8.3",
         "uuid": "^13.0.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "create-docs:process": "node scripts/mintlify-post-processing/file-processing/file-processing.js"
   },
   "dependencies": {
-    "axios": "^1.18.1",
+    "axios": "1.18.1",
     "partysocket": "^0.0.23",
     "socket.io-client": "^4.8.3",
     "uuid": "^13.0.2"


### PR DESCRIPTION
## What and why

`axios: "^1.18.1"` → `axios: "1.18.1"`. The resolved version does not change — the lockfile has always said `1.18.1`.

**A library's lockfile does not constrain its consumers.** Deno and Cloudflare Workers resolve `npm:@base44/sdk@x.y.z` against this `package.json`'s range, so the caret meant every generated-function redeploy picked whatever `1.x` npm had published most recently.

## The outage this caused

axios `1.20.0` shipped. Redeploys began resolving it, and the Deno runtime runs `--cached-only` against a cache warmed with `1.18.1`, so **any edited function 502'd on cold start** while untouched warm functions kept serving. Two automations auto-paused after consecutive failures (`recoverStuckProcessingOrders`, `createAbandonmentCoupon`). The reported error is exactly this: `npm package not found in cache: "axios", --cached-only is specified`.

## Supply-chain angle

This repo's `minimumReleaseAge` gives a 7-day cooldown, but that applies at *our* install time. A consumer resolving a caret at deploy time gets a package published minutes ago with **no cooldown at all** — the hazard apper's `CLAUDE.md` calls out for `npm:` specifiers.

## Scope

- Inert for anything installing from the lockfile (`npm ci` verified consistent, resolved version identical).
- Only changes what an `npm:` consumer resolves — which is the point.
- `236 tests pass`, typecheck and eslint clean.

## Does NOT fix the live incident

Functions already generated pin `@base44/sdk@0.8.40`, whose published `package.json` still carries the caret and is immutable. **The Deno npm cache still needs `axios@1.20.0` warmed** to recover those. This closes the hole for functions generated after the next release.