### PR TITLE
fix(auth): drop the stored token before redirecting to login

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -1,4 +1,6 @@
 import { AxiosInstance } from "axios";
+
+import { removeAccessToken } from "../utils/auth-utils.js";
 import {
   AuthModuleOptions,
   InternalAuthModule,
@@ -75,19 +77,6 @@ function loginViaPopup(
   }, 500);
 
   window.addEventListener("message", onMessage);
-}
-
-function removeStoredAccessToken() {
-  if (typeof window === "undefined" || !window.localStorage) {
-    return;
-  }
-  try {
-    window.localStorage.removeItem("base44_access_token");
-    // "token" is the key the platform-v2 built-in SDK used
-    window.localStorage.removeItem("token");
-  } catch (e) {
-    console.error("Failed to remove token from localStorage:", e);
-  }
 }
 
 /**
@@ -170,7 +159,8 @@ export function createAuthModule(
 
       // The login page must not boot with the token that just got us here,
       // or a rejected token redirects to /login forever.
-      removeStoredAccessToken();
+      removeAccessToken({});
+      removeAccessToken({ storageKey: "token" });
       window.location.href = loginUrl;
     },
 
@@ -217,7 +207,8 @@ export function createAuthModule(
 
       // Only do the rest if in a browser environment
       if (typeof window !== "undefined") {
-        removeStoredAccessToken();
+        removeAccessToken({});
+        removeAccessToken({ storageKey: "token" });
 
         // Determine the from_url parameter
         const fromUrl = redirectUrl || window.location.href;

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -77,6 +77,19 @@ function loginViaPopup(
   window.addEventListener("message", onMessage);
 }
 
+function removeStoredAccessToken() {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.removeItem("base44_access_token");
+    // "token" is the key the platform-v2 built-in SDK used
+    window.localStorage.removeItem("token");
+  } catch (e) {
+    console.error("Failed to remove token from localStorage:", e);
+  }
+}
+
 /**
  * Creates the auth module for the Base44 SDK.
  *
@@ -155,7 +168,9 @@ export function createAuthModule(
       // Build the login URL
       const loginUrl = `${options.appBaseUrl}/login?from_url=${encodeURIComponent(redirectUrl)}`;
 
-      // Redirect to the login page
+      // The login page must not boot with the token that just got us here,
+      // or a rejected token redirects to /login forever.
+      removeStoredAccessToken();
       window.location.href = loginUrl;
     },
 
@@ -202,16 +217,7 @@ export function createAuthModule(
 
       // Only do the rest if in a browser environment
       if (typeof window !== "undefined") {
-        // Remove token from localStorage
-        if (window.localStorage) {
-          try {
-            window.localStorage.removeItem("base44_access_token");
-            // Remove "token" that is set by the built-in SDK of platform version 2
-            window.localStorage.removeItem("token");
-          } catch (e) {
-            console.error("Failed to remove token from localStorage:", e);
-          }
-        }
+        removeStoredAccessToken();
 
         // Determine the from_url parameter
         const fromUrl = redirectUrl || window.location.href;

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -79,6 +79,12 @@ function loginViaPopup(
   window.addEventListener("message", onMessage);
 }
 
+// "token" is the key the platform-v2 built-in SDK wrote.
+function removeStoredAccessTokens() {
+  removeAccessToken({});
+  removeAccessToken({ storageKey: "token" });
+}
+
 /**
  * Creates the auth module for the Base44 SDK.
  *
@@ -159,8 +165,7 @@ export function createAuthModule(
 
       // The login page must not boot with the token that just got us here,
       // or a rejected token redirects to /login forever.
-      removeAccessToken({});
-      removeAccessToken({ storageKey: "token" });
+      removeStoredAccessTokens();
       window.location.href = loginUrl;
     },
 
@@ -207,8 +212,7 @@ export function createAuthModule(
 
       // Only do the rest if in a browser environment
       if (typeof window !== "undefined") {
-        removeAccessToken({});
-        removeAccessToken({ storageKey: "token" });
+        removeStoredAccessTokens();
 
         // Determine the from_url parameter
         const fromUrl = redirectUrl || window.location.href;

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -434,7 +434,7 @@ describe('Auth Module', () => {
       base44.auth.logout();
       
       // Verify error was logged
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to remove token from localStorage:', expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith('Error removing token from local storage:', expect.any(Error));
       
       // Restore
       consoleSpy.mockRestore();

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -287,6 +287,21 @@ describe('Auth Module', () => {
       global.window = originalWindow;
     });
 
+    test('should drop the stored token before redirecting to login', () => {
+      const mockLocalStorage = { removeItem: vi.fn(), getItem: vi.fn(), setItem: vi.fn(), clear: vi.fn() };
+      const mockLocation = { href: 'https://example.com/current-page' };
+      const originalWindow = global.window;
+      global.window = { localStorage: mockLocalStorage, location: mockLocation };
+
+      base44.auth.redirectToLogin();
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('base44_access_token');
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('token');
+      expect(mockLocation.href).toContain('/login?from_url=');
+
+      global.window = originalWindow;
+    });
+
     test('should use appBaseUrl for login redirect when provided', () => {
       const customAppBaseUrl = 'https://custom-app.example.com';
       const clientWithCustomUrl = createClient({


### PR DESCRIPTION
`redirectToLogin()` navigated to `/login` while leaving the rejected token in `localStorage`. Apps that serve their own login page then boot again with the same dead token, get another 401, and redirect to `/login` forever — the loop that hit ~3k custom-auth apps when the legacy app-user signing key was cut off (https://base44workspace.slack.com/archives/C095K108GKU/p1787509962872049).

The storage clear that `logout()` already does is extracted into a helper and `redirectToLogin()` calls it before navigating. Apps pick this up on their next build/publish; the installed population is covered server-side by base44-dev/apper#21743.