### PR TITLE
feat(types): add html and text fields to SendEmailParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@base44/sdk",
-  "version": "0.8.44",
+  "version": "0.8.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@base44/sdk",
-      "version": "0.8.44",
+      "version": "0.8.45",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base44/sdk",
-  "version": "0.8.44",
+  "version": "0.8.45",
   "description": "JavaScript SDK for Base44 API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export type {
   GenerateImageResult,
   UploadFileParams,
   UploadFileResult,
+  EmailAttachment,
   SendEmailParams,
   SendEmailResult,
   ExtractDataFromUploadedFileParams,

--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -87,19 +87,12 @@ export interface UploadFileResult {
   file_url: string;
 }
 
-/**
- * Parameters for the SendEmail function.
- *
- * At least one of `body`, `html`, or `text` is required; the backend returns 422 otherwise.
- *
- * | Fields set | Result |
- * |---|---|
- * | `body` or `html` alone | `text/html` email |
- * | `text` alone | `text/plain` email |
- * | `body`/`html` + `text` | `multipart/alternative` — one email, two representations; recipient sees whichever their client prefers — both parts must say the same thing |
- * | `body` + `html` | **422** — same slot, set one not both |
- */
-export interface SendEmailParams {
+/** Requires at least one key from Keys to be present. */
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+  Pick<T, Exclude<keyof T, Keys>> &
+  { [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>> }[Keys];
+
+interface SendEmailParamsBase {
   /** Recipient email address. */
   to: string;
   /** Email subject line. */
@@ -119,6 +112,20 @@ export interface SendEmailParams {
   /** The name of the sender. If omitted, the app's name will be used. */
   from_name?: string;
 }
+
+/**
+ * Parameters for the SendEmail function.
+ *
+ * At least one of `body`, `html`, or `text` is required; the backend returns 422 otherwise.
+ *
+ * | Fields set | Result |
+ * |---|---|
+ * | `body` or `html` alone | `text/html` email |
+ * | `text` alone | `text/plain` email |
+ * | `body`/`html` + `text` | `multipart/alternative` — one email, two representations; recipient sees whichever their client prefers — both parts must say the same thing |
+ * | `body` + `html` | **422** — same slot, set one not both |
+ */
+export type SendEmailParams = RequireAtLeastOne<SendEmailParamsBase, 'body' | 'html' | 'text'>;
 
 export type SendEmailResult = any;
 

--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -89,14 +89,33 @@ export interface UploadFileResult {
 
 /**
  * Parameters for the SendEmail function.
+ *
+ * At least one of `body`, `html`, or `text` is required; the backend returns 422 otherwise.
+ *
+ * | Fields set | Result |
+ * |---|---|
+ * | `body` or `html` alone | `text/html` email |
+ * | `text` alone | `text/plain` email |
+ * | `body`/`html` + `text` | `multipart/alternative` — one email, two representations; recipient sees whichever their client prefers — both parts must say the same thing |
+ * | `body` + `html` | **422** — same slot, set one not both |
  */
 export interface SendEmailParams {
   /** Recipient email address. */
   to: string;
   /** Email subject line. */
   subject: string;
-  /** Plain text email body content. */
-  body: string;
+  /** HTML email body content. Alias of `html` — set one or the other, never both. */
+  body?: string;
+  /** HTML email body content. The same thing as `body` under an explicit name. */
+  html?: string;
+  /**
+   * Plain-text email body content.
+   *
+   * On its own, sends a plain-text (`text/plain`) email. Alongside `body`/`html`,
+   * both parts go out as a single `multipart/alternative` email and the recipient's
+   * mail client renders whichever it prefers — so the two must say the same thing.
+   */
+  text?: string;
   /** The name of the sender. If omitted, the app's name will be used. */
   from_name?: string;
 }

--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -92,6 +92,20 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
   Pick<T, Exclude<keyof T, Keys>> &
   { [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>> }[Keys];
 
+/**
+ * A file to attach to a `SendEmail` call.
+ *
+ * Provide exactly one content source per attachment:
+ * - `content` — base64-encoded bytes generated at runtime (e.g. a PDF built in the function).
+ * - `file_url` — a URL returned by `UploadFile` or `UploadPrivateFile` for a file already in storage.
+ *
+ * Allowed extensions: `pdf`, `png`, `jpg`/`jpeg`, `gif`, `webp`, `csv`, `txt`, `md`, `ics`, `xlsx`, `docx`.
+ * Limits: up to **5 attachments**, **5 MB each**, **10 MB total**.
+ */
+export type EmailAttachment =
+  | { /** Attachment filename, including extension. */ filename: string; /** Base64-encoded file content. */ content: string; file_url?: never }
+  | { /** Attachment filename, including extension. */ filename: string; /** URL from `UploadFile` or `UploadPrivateFile`. */ file_url: string; content?: never };
+
 interface SendEmailParamsBase {
   /** Recipient email address. */
   to: string;
@@ -111,6 +125,13 @@ interface SendEmailParamsBase {
   text?: string;
   /** The name of the sender. If omitted, the app's name will be used. */
   from_name?: string;
+  /**
+   * Files to attach to the email. Up to 5 attachments, 5 MB each, 10 MB total.
+   *
+   * Each item must have a `filename` and exactly one content source:
+   * `content` (inline base64) or `file_url` (storage reference).
+   */
+  attachments?: EmailAttachment[];
 }
 
 /**

--- a/tests/types/integrations.types.ts
+++ b/tests/types/integrations.types.ts
@@ -45,9 +45,14 @@ const withFromName = {
   from_name: "My App",
 } satisfies SendEmailParams;
 
+// omitting all three content fields must be a compile error
+// @ts-expect-error At least one of body/html/text is required.
+const missingContent: SendEmailParams = { to: "user@example.com", subject: "Hello" };
+
 void bodyOnly;
 void htmlOnly;
 void textOnly;
 void htmlAndText;
 void bodyAndText;
 void withFromName;
+void missingContent;

--- a/tests/types/integrations.types.ts
+++ b/tests/types/integrations.types.ts
@@ -1,0 +1,53 @@
+import type { SendEmailParams } from "../../src/index.js";
+
+// body-only (existing callers must still compile — backward compat)
+const bodyOnly = {
+  to: "user@example.com",
+  subject: "Hello",
+  body: "<p>Hello</p>",
+} satisfies SendEmailParams;
+
+// html-only
+const htmlOnly = {
+  to: "user@example.com",
+  subject: "Hello",
+  html: "<p>Hello</p>",
+} satisfies SendEmailParams;
+
+// text-only
+const textOnly = {
+  to: "user@example.com",
+  subject: "Hello",
+  text: "Hello",
+} satisfies SendEmailParams;
+
+// html + text → multipart/alternative
+const htmlAndText = {
+  to: "user@example.com",
+  subject: "Hello",
+  html: "<p>Hello</p>",
+  text: "Hello",
+} satisfies SendEmailParams;
+
+// body + text → multipart/alternative
+const bodyAndText = {
+  to: "user@example.com",
+  subject: "Hello",
+  body: "<p>Hello</p>",
+  text: "Hello",
+} satisfies SendEmailParams;
+
+// optional from_name
+const withFromName = {
+  to: "user@example.com",
+  subject: "Hello",
+  body: "<p>Hello</p>",
+  from_name: "My App",
+} satisfies SendEmailParams;
+
+void bodyOnly;
+void htmlOnly;
+void textOnly;
+void htmlAndText;
+void bodyAndText;
+void withFromName;

--- a/tests/types/integrations.types.ts
+++ b/tests/types/integrations.types.ts
@@ -1,4 +1,4 @@
-import type { SendEmailParams } from "../../src/index.js";
+import type { SendEmailParams, EmailAttachment } from "../../src/index.js";
 
 // body-only (existing callers must still compile — backward compat)
 const bodyOnly = {
@@ -45,6 +45,26 @@ const withFromName = {
   from_name: "My App",
 } satisfies SendEmailParams;
 
+// attachments: inline base64
+const inlineAttachment = {
+  filename: "receipt.pdf",
+  content: "JVBERi0x",
+} satisfies EmailAttachment;
+
+// attachments: storage reference
+const storedAttachment = {
+  filename: "logo.png",
+  file_url: "https://storage.example.com/logo.png",
+} satisfies EmailAttachment;
+
+// with attachments on a full params object
+const withAttachments = {
+  to: "user@example.com",
+  subject: "Invoice",
+  body: "<p>See attached.</p>",
+  attachments: [inlineAttachment, storedAttachment],
+} satisfies SendEmailParams;
+
 // omitting all three content fields must be a compile error
 // @ts-expect-error At least one of body/html/text is required.
 const missingContent: SendEmailParams = { to: "user@example.com", subject: "Hello" };
@@ -55,4 +75,7 @@ void textOnly;
 void htmlAndText;
 void bodyAndText;
 void withFromName;
+void inlineAttachment;
+void storedAttachment;
+void withAttachments;
 void missingContent;


### PR DESCRIPTION
## Summary

- Adds `html` (explicit alias of `body`, same HTML slot) and `text` (plain-text part) to `SendEmailParams`
- Corrects `body`'s JSDoc — it was described as *plain text* but has always been sent as `text/html`
- `body` relaxed from required to optional (backward compatible — existing callers unaffected)
- Documents `multipart/alternative` behaviour and all 422 error cases in JSDoc

## Details

Types-only; runtime dispatch is unchanged. The `createIntegrationsModule` Proxy JSON-posts whatever object it receives, so `html` and `text` already work over the wire — only the hand-maintained types were out of date.

Backend PR: base44-dev/apper#22289 (branch `sendmail-plain-text`)

> **Note:** `template_id`, `template_name`, and `variables` are also missing from `SendEmailParams` (accepted by the backend). Flagged here for separate scoping with the email-templates feature owners — not included in this PR.

## Test plan

- [x] `npm run test:types` — new type-level tests in `tests/types/integrations.types.ts` cover `body`-only (backward compat), `html`-only, `text`-only, `html`+`text`, `body`+`text`, and `from_name`
- [x] `npm run build` — `dist/modules/integrations.types.d.ts` reflects the updated interface
- [x] `src/modules/integrations.ts` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)