### PR TITLE
fix(types): sync InvokeLLM model union with backend RuntimeModel

### DIFF
--- a/src/modules/integrations.types.ts
+++ b/src/modules/integrations.types.ts
@@ -48,9 +48,9 @@ export interface InvokeLLMParams {
   prompt: string;
   /** Optionally specify a model to override the app-level model setting for this specific call.
    *
-   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5_4"`, `"gpt_5_5"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`, `"claude_opus_4_7"`, `"claude_opus_4_8"`
+   * Options: `"gpt_5_mini"`, `"gemini_3_flash"`, `"gpt_5_4"`, `"gpt_5_6_sol"`, `"gpt_5_6_luna"`, `"gemini_3_1_pro"`, `"claude_sonnet_4_6"`, `"claude_opus_4_6"`, `"claude_opus_4_7"`, `"claude_opus_4_8"`, `"claude-sonnet-5"`
    */
-  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5_4' | 'gpt_5_5' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6' | 'claude_opus_4_7' | 'claude_opus_4_8';
+  model?: 'gpt_5_mini' | 'gemini_3_flash' | 'gpt_5_4' | 'gpt_5_6_sol' | 'gpt_5_6_luna' | 'gemini_3_1_pro' | 'claude_sonnet_4_6' | 'claude_opus_4_6' | 'claude_opus_4_7' | 'claude_opus_4_8' | 'claude-sonnet-5';
   /** If set to `true`, the LLM will use Google Search, Maps, and News to gather real-time context before answering.
    * @default false
    */


### PR DESCRIPTION
## Summary

Drift found between `RuntimeModel` enum in `apper` and the `model?` union on `InvokeLLMParams` in the SDK.

| Model | Status |
|---|---|
| `gpt_5_5` | Removed — retired alias, mapped to `gpt_5_6_sol` in backend |
| `gpt_5_6_sol` | Added |
| `gpt_5_6_luna` | Added |
| `claude-sonnet-5` | Added |

## Test plan

- [ ] TypeScript consumers passing any of the new model values no longer get a type error
- [ ] `gpt_5_5` is no longer accepted at the type level (breaking only for incorrect usage)