### PR TITLE
fix(analytics): allow clients to disable tracking

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ import { createUsersModule } from "./modules/users.js";
 import { RoomsSocket, RoomsSocketConfig } from "./utils/socket-utils.js";
 import type {
   Base44Client,
+  CreateClientAnalyticsConfig,
   CreateClientConfig,
   CreateClientOptions,
 } from "./client.types.js";
@@ -27,7 +28,12 @@ import {
 } from "./modules/actors.js";
 
 // Re-export client types
-export type { Base44Client, CreateClientConfig, CreateClientOptions };
+export type {
+  Base44Client,
+  CreateClientAnalyticsConfig,
+  CreateClientConfig,
+  CreateClientOptions,
+};
 
 /**
  * Creates a Base44 client.
@@ -70,6 +76,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
   const {
     serverUrl = "https://base44.app",
     appId,
+    analytics,
     token,
     serviceToken,
     requiresAuth = false,
@@ -246,6 +253,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       appId,
       userAuthModule,
+      enabled: analytics?.enabled,
     }),
     actors: actorsModule.module,
     cleanup: () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -253,7 +253,7 @@ export function createClient(config: CreateClientConfig): Base44Client {
       serverUrl,
       appId,
       userAuthModule,
-      enabled: analytics?.enabled,
+      enabled: analytics?.enabled ?? true,
     }),
     actors: actorsModule.module,
     cleanup: () => {

--- a/src/client.types.ts
+++ b/src/client.types.ts
@@ -36,6 +36,22 @@ export interface CreateClientOptions {
 }
 
 /**
+ * Configuration for the SDK's app analytics module.
+ */
+export interface CreateClientAnalyticsConfig {
+  /**
+   * Whether app analytics is enabled for this client.
+   *
+   * When disabled, automatic analytics and calls to `analytics.track()` are
+   * no-ops. The SDK does not create an analytics session identifier, start
+   * heartbeat timers, or send analytics requests.
+   *
+   * @defaultValue `true`
+   */
+  enabled: boolean;
+}
+
+/**
  * Configuration for creating a Base44 client.
  */
 export interface CreateClientConfig {
@@ -61,6 +77,12 @@ export interface CreateClientConfig {
    * It's the string between `/apps/` and `/editor/`.
    */
   appId: string;
+  /**
+   * Controls app analytics for this client.
+   *
+   * Omit this option to preserve the default analytics behavior.
+   */
+  analytics?: CreateClientAnalyticsConfig;
   /**
    * User authentication token. Used to authenticate as a specific user.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   createClient,
   createClientFromRequest,
   type Base44Client,
+  type CreateClientAnalyticsConfig,
   type CreateClientConfig,
   type CreateClientOptions,
 } from "./client.js";
@@ -25,6 +26,7 @@ export {
 
 export type {
   Base44Client,
+  CreateClientAnalyticsConfig,
   CreateClientConfig,
   CreateClientOptions,
   Base44ErrorJSON,

--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -62,6 +62,7 @@ export interface AnalyticsModuleArgs {
   serverUrl: string;
   appId: string;
   userAuthModule: InternalAuthModule;
+  enabled?: boolean;
 }
 
 export const createAnalyticsModule = ({
@@ -69,6 +70,7 @@ export const createAnalyticsModule = ({
   serverUrl,
   appId,
   userAuthModule,
+  enabled,
 }: AnalyticsModuleArgs) => {
   // prevent overflow of events //
   const { maxQueueSize, throttleTime, batchSize } = analyticsSharedState.config;
@@ -77,7 +79,7 @@ export const createAnalyticsModule = ({
   // so the per-callsite `typeof window` guards below aren't enough to keep it
   // from touching `document` (e.g. `document.referrer` on init). Node/SSR is
   // still handled by those `window` guards, so this doesn't affect it.
-  if (!analyticsSharedState.config?.enabled || isReactNative) {
+  if (enabled === false || !analyticsSharedState.config?.enabled || isReactNative) {
     return {
       track: () => {},
       cleanup: () => {},

--- a/src/modules/analytics.ts
+++ b/src/modules/analytics.ts
@@ -62,7 +62,7 @@ export interface AnalyticsModuleArgs {
   serverUrl: string;
   appId: string;
   userAuthModule: InternalAuthModule;
-  enabled?: boolean;
+  enabled: boolean;
 }
 
 export const createAnalyticsModule = ({
@@ -79,7 +79,7 @@ export const createAnalyticsModule = ({
   // so the per-callsite `typeof window` guards below aren't enough to keep it
   // from touching `document` (e.g. `document.referrer` on init). Node/SSR is
   // still handled by those `window` guards, so this doesn't affect it.
-  if (enabled === false || !analyticsSharedState.config?.enabled || isReactNative) {
+  if (!enabled || !analyticsSharedState.config?.enabled || isReactNative) {
     return {
       track: () => {},
       cleanup: () => {},

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -69,6 +69,7 @@ describe("Analytics Module", () => {
   afterEach(() => {
     vi.clearAllMocks();
     base44.cleanup();
+    vi.unstubAllGlobals();
     sharedState = null;
   });
 
@@ -87,6 +88,38 @@ describe("Analytics Module", () => {
     expect(base44.analytics.track).toHaveBeenCalledWith({
       eventName: "test-event",
     });
+  });
+
+  test("should have no analytics side effects when disabled in client config", () => {
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    };
+    const addEventListener = vi.fn();
+    vi.stubGlobal("localStorage", storage);
+    vi.stubGlobal("document", { referrer: "", visibilityState: "visible" });
+    vi.stubGlobal("window", {
+      addEventListener,
+      removeEventListener: vi.fn(),
+      history: { replaceState: vi.fn() },
+      localStorage: storage,
+      location: { origin: "https://example.com", pathname: "/", search: "" },
+    });
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    const disabled = createClient({
+      serverUrl,
+      appId,
+      analytics: { enabled: false },
+    });
+    disabled.analytics.track({ eventName: "should-not-track" });
+
+    expect(sharedState?.requestsQueue).toEqual([]);
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
+
+    disabled.cleanup();
   });
 
   test("should clear the memoized session context on reset", () => {


### PR DESCRIPTION
<!-- pr-autofix-intent -->
## Intent (for reviewers & PR Autofix)

### What this PR does

Adds `analytics: { enabled: false }` to `CreateClientConfig`, making analytics a no-op before any storage, timer, listener, or request side effects while preserving the current default when omitted.

### Key decisions & why

- Keep analytics enabled by default for backward compatibility; Base44-generated apps can opt out immediately while consent integration is built.
- Disable the full analytics module, including custom `analytics.track()`, because partial automatic-only gating could still send non-consented custom events.

### What NOT to touch

- The existing `analytics-enable` URL switch remains intentional as an independent opt-out path.
- Existing analytics defaults remain intentional; the consumer app template will explicitly opt out after this SDK version is published.

### Tradeoffs / follow-ups

- Opted-out apps lose built-in visits, live visitors, path/referrer, session-duration, and custom analytics events.
- Existing published bundles require rebuild/republication; SDK publication alone does not patch them.
<!-- /pr-autofix-intent -->

## Summary

- add public per-client analytics enablement config
- short-circuit analytics before storage, timers, listeners, or requests
- add no-side-effects regression coverage

## Testing

- `npm test`
- `npm run lint`
- `npm run build`
