### PR TITLE
Fix the failing security audit: bump socket.io-parser and run on Node 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4951,9 +4951,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
The **Security Audit / npm audit (dependencies)** check has failed on `main` since 2026-09-01, so it currently blocks every open PR.

There are **two independent causes**. Fixing either one alone leaves the job red.

## Cause 1: a retired registry endpoint

npm 10, which ships with Node 20, calls the legacy quick-audit endpoint. The registry is retiring it and now answers 400:

```
npm notice This endpoint is being retired. Use the bulk advisory endpoint instead.
npm warn audit 400 Bad Request - POST .../security/audits/quick
npm error audit endpoint returned an error
```

npm exits 1 **before evaluating a single advisory**, so this fails whether or not the project has a vulnerability. I confirmed that by pushing the dependency fix on its own first: the job still failed, with an identical log and nothing about `socket.io-parser`.

npm 11 uses the bulk advisory endpoint. Node 24 is already what `manual-publish` and `preview-publish` run, and it is what `.npmrc` calls for, since `min-release-age` needs npm >= 11.10.0 and is silently ignored on npm 10. This workflow and `lint`/`unit-tests` were the remaining ones on 20.x.

## Cause 2: a real high-severity vulnerability

With a working endpoint, the audit fails for a legitimate reason:

```
$ npm audit --omit=dev --audit-level=high
socket.io-parser  4.0.0 - 4.2.6
Severity: high
Socket.IO: Zero-attachment Memory Exhaustion - GHSA-2m8v-j782-fhvr
$ echo $?
1
```

The path is production, so `--omit=dev` does not skip it:

```
@base44/sdk → socket.io-client@4.8.3 → socket.io-parser@4.2.6
```

`socket.io-client@4.8.3` declares `socket.io-parser: ~4.2.4`, and the patched `4.2.7` is already inside that range, so this is a **lockfile refresh only**. No `package.json` change, no declared range change, no major or minor bump of any direct dependency.

```diff
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
```

## Verification

- `npm audit --omit=dev --audit-level=high` reports **0 vulnerabilities** and exits **0** locally
- The integrity hash was checked by hashing the tarball rather than trusting the registry response, and it matches
- The `resolved` URL is normalised to `registry.npmjs.org`. `npm update` had written an internal Wix registry URL, which would have been the only such entry among 393

The Node bump cannot be reproduced locally, because `registry.npmjs.org` is not reachable from a Wix network and a local run therefore goes through a proxy that does not exhibit the fault. It is verified by this job.

## Follow-up, not done here

`lint` and `unit-tests` are still on Node 20.x while the publish workflows are on 24. Worth aligning, but it is a behaviour change for those jobs and does not belong in a fix for a red audit.